### PR TITLE
Fix convert_cybox.py - convert_uri() function

### DIFF
--- a/stix2elevator/convert_cybox.py
+++ b/stix2elevator/convert_cybox.py
@@ -21,7 +21,7 @@ def convert_address(add):
 
 
 def convert_uri(uri):
-    return {"type": "url-object", "value": + uri.value.value}
+    return {"type": "url", "value": uri.value.value}
 
 
 def create_directory(file):


### PR DESCRIPTION
removed unnecessary "+" operator, and changed type to "url" (according to STIX specification)