### PR TITLE
Fix marking-definition without created_by_ref

### DIFF
--- a/idioms-json/Appendix_G_IOCs_Full.json
+++ b/idioms-json/Appendix_G_IOCs_Full.json
@@ -3,6 +3,7 @@
     "objects": [
         {
             "created": "2017-05-03T14:09:03.121Z",
+            "created_by_ref": "identity--25b4ac53-b009-44a7-adac-6377624c6a31",
             "definition": {
                 "statement": "APT1: Exposing One of China's Cyber Espionage Units (the \"APT1 Report\") is copyright 2013 by Mandiant Corporation and can be downloaded at intelreport.mandiant.com.  This XML file using the STIX standard was created by The MITRE Corporation using the content of the APT1 Report with Mandiant's permission.  Mandiant is not responsible for the content of this file."
             },

--- a/idioms-json/Mandiant_APT1_Report.json
+++ b/idioms-json/Mandiant_APT1_Report.json
@@ -3,6 +3,7 @@
     "objects": [
         {
             "created": "2017-05-03T14:10:22.296Z",
+            "created_by_ref": "identity--38b25d5f-86fa-4d1f-b549-dbcc442620c1",
             "definition": {
                 "statement": "APT1: Exposing One of China's Cyber Espionage Units (the \"APT1 Report\") is copyright 2013 by Mandiant Corporation and can be downloaded at intelreport.mandiant.com.  This XML file using the STIX standard was created by The MITRE Corporation using the content of the APT1 Report with Mandiant's permission.  Mandiant is not responsible for the content of this file."
             },

--- a/idioms-json/fireeye-pivy-report-with-indicators.json
+++ b/idioms-json/fireeye-pivy-report-with-indicators.json
@@ -3,6 +3,7 @@
     "objects": [
         {
             "created": "2017-05-03T14:09:50.684Z",
+            "created_by_ref": "identity--dfb67e12-388e-40dd-bc26-c13fdb20b1dd",
             "definition": {
                 "statement": "Copyright 2013 FireEye, Inc."
             },


### PR DESCRIPTION
Small issue when converting the identity from the package and the identity was marked. Since the identity instance is being built, the variable parent_created_by_ref is still None so there was no way to propagate the existence of the created_by_ref for the marking-definition being built.