### PR TITLE
Add support for silent option in validator

### DIFF
--- a/stix2elevator/__init__.py
+++ b/stix2elevator/__init__.py
@@ -40,6 +40,7 @@ def elevate_file(fn):
 
     try:
         output.set_level(validator_options.verbose)
+        output.set_silent(validator_options.silent)
 
         container = stixmarx.parse(fn)
         stix_package = container.package
@@ -82,6 +83,7 @@ def elevate_string(string):
 
     try:
         output.set_level(validator_options.verbose)
+        output.set_silent(validator_options.silent)
 
         io = StringIO(string)
         container = stixmarx.parse(io)
@@ -123,6 +125,7 @@ def elevate_package(package):
 
     try:
         output.set_level(validator_options.verbose)
+        output.set_silent(validator_options.silent)
 
         # It needs to be re-parsed.
         container = stixmarx.parse(StringIO(package.to_xml()))


### PR DESCRIPTION
This change allows the validator to silenced when used through the elevator.