### PR TITLE
Prevent outputting converted JSON twice

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,7 @@ STIX 1.1.1 - 1.2.1 content to STIX 2.0 content::
       --validator-args VALIDATOR_ARGS
                             Arguments to pass to stix-validator. Default: --strict-
                             types Example: stix2_elevator.py <file> --validator-
-                            args "-v --strict-types -d 212"
+                            args="-v --strict-types -d 212"
 
       -e ENABLE, --enable ENABLE
                             A comma-separated list of the stix2-elevator messages

--- a/stix2elevator/__init__.py
+++ b/stix2elevator/__init__.py
@@ -54,7 +54,6 @@ def elevate_file(fn):
 
         output.print_results(validation_results)
         if get_option_value("policy") == "no_policy" or (not MESSAGES_GENERATED and validation_results._is_valid):
-            print(json_string)
             return json_string
         else:
             return None

--- a/stix2elevator/cli.py
+++ b/stix2elevator/cli.py
@@ -97,7 +97,7 @@ def _get_arg_parser(is_script=True):
     parser.add_argument(
         "--validator-args",
         help="Arguments to pass to stix-validator. Default: --strict-types\n\n"
-             "Example: stix2_elevator.py <file> --validator-args \"-v --strict-types -d 212\"",
+             "Example: stix2_elevator.py <file> --validator-args=\"-v --strict-types -d 212\"",
         dest="validator_args",
         action="store",
         default="--strict-types"


### PR DESCRIPTION
Also, fix help message for using validator args.