### PR TITLE
when no policy do not validate

### DIFF
--- a/stix2elevator/__init__.py
+++ b/stix2elevator/__init__.py
@@ -51,14 +51,16 @@ def elevate_file(fn):
                                  indent=4,
                                  separators=(',', ': '),
                                  sort_keys=True)
-        validation_results = validate_string(json_string, validator_options)
 
-        output.print_results(validation_results)
-        if get_option_value("policy") == "no_policy" or (not MESSAGES_GENERATED and validation_results._is_valid):
-            print(json_string)
+        if get_option_value("policy") == "no_policy":
             return json_string
         else:
-            return None
+            validation_results = validate_string(json_string, validator_options)
+            output.print_results(validation_results)
+            if not MESSAGES_GENERATED and validation_results._is_valid:
+                return json_string
+            else:
+                return None
 
     except ValidationError as ex:
         output.error("Validation error occurred: '%s'" % ex,
@@ -98,12 +100,16 @@ def elevate_string(string):
                                  indent=4,
                                  separators=(',', ': '),
                                  sort_keys=True)
-        validation_results = validate_string(json_string, validator_options)
-        output.print_results(validation_results)
-        if get_option_value("policy") == "no_policy" or (not MESSAGES_GENERATED and validation_results._is_valid):
+
+        if get_option_value("policy") == "no_policy":
             return json_string
         else:
-            return None
+            validation_results = validate_string(json_string, validator_options)
+            output.print_results(validation_results)
+            if not MESSAGES_GENERATED and validation_results._is_valid:
+                return json_string
+            else:
+                return None
 
     except ValidationError as ex:
         output.error("Validation error occurred: '%s'" % ex,
@@ -143,12 +149,15 @@ def elevate_package(package):
                                  indent=4,
                                  separators=(',', ': '),
                                  sort_keys=True)
-        validation_results = validate_string(json_string, validator_options)
-        output.print_results(validation_results)
-        if get_option_value("policy") == "no_policy" or (not MESSAGES_GENERATED and validation_results._is_valid):
+        if get_option_value("policy") == "no_policy":
             return json_string
         else:
-            return None
+            validation_results = validate_string(json_string, validator_options)
+            output.print_results(validation_results)
+            if not MESSAGES_GENERATED and validation_results._is_valid:
+                return json_string
+            else:
+                return None
 
     except ValidationError as ex:
         output.error("Validation error occurred: '%s'" % ex,


### PR DESCRIPTION
Only run the validation if we are going to do anything with the results. This reduces run time and print output when no_policy is set.