### PR TITLE
Modification in "As a script", Usage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,8 @@ As A Script
 The elevator comes with a bundled script which you can use to elevate
 STIX 1.1.1 - 1.2.1 content to STIX 2.0 content::
 
-    usage: cli.py [-h] [--incidents] [--no-squirrel-gaps] [--infrastructure]
+    $ stix2_elevator
+    usage: stix2_elevator [-h] [--incidents] [--no-squirrel-gaps]
               [--package-created-by-id PACKAGE_CREATED_BY_ID]
               [--default-timestamp DEFAULT_TIMESTAMP]
               [--validator-args VALIDATOR_ARGS] [-e ENABLE] [-d DISABLE] [-s]


### PR DESCRIPTION
I have installed, but I couldn't find "cli.py".
It should be "stix2_elevator".