### PR TITLE
Gracefully handle unexpected formatting in STIX 1.x IDs

### DIFF
--- a/docs/warnings.rst
+++ b/docs/warnings.rst
@@ -129,6 +129,7 @@ Hive property, *[hive property name]*, is already a prefix of the key property, 
 The custom property name *[id]* contains whitespace, replacing it with underscores                                                          624     warn
 Found duplicate marking structure *[id]*                                                                                                    625     info
 *[hash_string]* is not a valid *[hash_type]* hash                                                                                           626     warn
+Unable to determine the STIX 2.0 type for *[id]*, which is malformed                                                                        627     error
 =========================================================================================================================================== ====    =====
 
 STIX Elevator conversion based on assumptions

--- a/stix2elevator/ids.py
+++ b/stix2elevator/ids.py
@@ -72,8 +72,12 @@ def generate_stix20_id(stix20_so_name, stix12_id=None, id_used=False):
             else:
                 return stix20_so_name + "--" + current_uuid
         else:
-            warn("Malformed id %s. Generated a new uuid", 605, stix12_id)
-            return stix20_so_name + "--" + text_type(uuid.uuid4())
+            if stix20_so_name:
+                warn("Malformed id %s. Generated a new uuid", 605, stix12_id)
+                return stix20_so_name + "--" + text_type(uuid.uuid4())
+            else:
+                error("Unable to determine the STIX 2.0 type for %s, which is malformed", 627, stix12_id)
+                return None
 
 
 _IDS_TO_NEW_IDS = {}


### PR DESCRIPTION
don't error exit if None passed into generate_stix20_id for the stix20 type name when the id is malformed.

Fix #114 