### PR TITLE
Python 2 & 3 compatible handling of XML bytes

### DIFF
--- a/stix2elevator/__init__.py
+++ b/stix2elevator/__init__.py
@@ -3,7 +3,7 @@ import json
 import logging
 
 import cybox.utils.caches
-from six import StringIO, binary_type
+from six import BytesIO, StringIO, binary_type
 from stix2validator import ValidationError, codes, output, validate_string
 from stix2validator.validator import FileValidationResults
 from stix.core import STIXPackage
@@ -170,7 +170,7 @@ def elevate_package(package):
         output.set_silent(validator_options.silent)
 
         # It needs to be re-parsed.
-        container = stixmarx.parse(StringIO(package.to_xml()))
+        container = stixmarx.parse(BytesIO(package.to_xml()))
         stix_package = container.package
         set_option_value("marking_container", container)
 


### PR DESCRIPTION
Fixed a Python 3 compatibility issue in `elevate_package()` that raises a `TypeError`. A STIX object's `to_xml()` method returns a `str` type in Python 2 and a `bytes` type in Python 3. This fix supports both.

# Before
## Python 2.7
```Python 2.7.12 (default, Oct 11 2016, 15:08:15) 
[GCC 4.4.7 20120313 (Red Hat 4.4.7-17)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from stix.core import STIXPackage
>>> from stix2elevator import elevate_package
>>> from stix2elevator.options import initialize_options
>>> initialize_options()
>>> elevate_package(STIXPackage())
u'{\n    "id": "bundle--af93b65f-b879-449e-9cfe-9a7d9d2131a3",\n    "spec_version": "2.0",\n    "type": "bundle"\n}'
>>> 
```
## Python 3.7
```Python 3.7.4 (default, Oct 12 2019, 18:55:45) 
[Clang 10.0.0 (clang-1000.11.45.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from stix.core import STIXPackage
>>> from stix2elevator import elevate_package
>>> from stix2elevator.options import initialize_options
>>> initialize_options()
>>> elevate_package(STIXPackage())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "***/cti-stix-elevator/stix2elevator/__init__.py", line 173, in elevate_package
    container = stixmarx.parse(StringIO(package.to_xml()))
TypeError: initial_value must be str or None, not bytes
>>>
```
# After
## Python 2.7
```Python 2.7.12 (default, Oct 11 2016, 15:08:15) 
[GCC 4.4.7 20120313 (Red Hat 4.4.7-17)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from stix.core import STIXPackage
>>> from stix2elevator import elevate_package
>>> from stix2elevator.options import initialize_options
>>> initialize_options()
>>> elevate_package(STIXPackage())
u'{\n    "id": "bundle--1d6a5f99-8641-4dfc-9514-ed93baaa5195",\n    "spec_version": "2.0",\n    "type": "bundle"\n}'
>>> 
```
## Python 3.7
```Python 3.7.4 (default, Oct 12 2019, 18:55:45) 
[Clang 10.0.0 (clang-1000.11.45.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from stix.core import STIXPackage
>>> from stix2elevator import elevate_package
>>> from stix2elevator.options import initialize_options
>>> initialize_options()
>>> elevate_package(STIXPackage())
'{\n    "id": "bundle--51ef82db-2a1d-4ea0-8e4f-bdbf8c8c52a5",\n    "spec_version": "2.0",\n    "type": "bundle"\n}'
>>> 
```