### PR TITLE
Threat Actor goals should be a list

### DIFF
--- a/stix2elevator/convert_stix.py
+++ b/stix2elevator/convert_stix.py
@@ -1467,7 +1467,7 @@ def convert_threat_actor(threat_actor, env):
     if threat_actor.intended_effects is not None:
         threat_actor_instance["goals"] = list()
         for g in threat_actor.intended_effects:
-            threat_actor_instance["goals"] = text_type(g)
+            threat_actor_instance["goals"].append(text_type(g.value))
     convert_controlled_vocabs_to_open_vocabs(threat_actor_instance,
                                              "labels" if get_option_value("spec_version") == "2.0" else "threat_actor_types",
                                              threat_actor.types,


### PR DESCRIPTION
## Fixes
- Threat Actor goals should be appended to a list.
- Get the actual value of the intended effect to add to the goals list.

## Before
![Screen Shot 2020-01-21 at 10 37 09 AM](https://user-images.githubusercontent.com/827774/72819756-cee3e400-3c3b-11ea-91f0-b5e17bf13a5d.png)

## After
![Screen Shot 2020-01-21 at 10 38 03 AM](https://user-images.githubusercontent.com/827774/72819765-d3a89800-3c3b-11ea-8706-d90f14db6b0f.png)
