### PR TITLE
Fix Email DateTime support

### DIFF
--- a/stix2elevator/convert_cybox.py
+++ b/stix2elevator/convert_cybox.py
@@ -539,7 +539,7 @@ def convert_email_message(email_message, obj1x_id):
     if email_message.header:
         header = email_message.header
         if header.date:
-            email_dict["date"] = convert_timestamp_to_string(header.date)
+            email_dict["date"] = convert_timestamp_to_string(header.date.value)
         if header.content_type:
             email_dict["content_type"] = text_type(header.content_type)
         if header.subject:

--- a/stix2elevator/utils.py
+++ b/stix2elevator/utils.py
@@ -4,6 +4,7 @@ from datetime import datetime
 import os
 import textwrap
 
+from cybox.common.properties import DateTime
 from six import binary_type, iteritems, text_type
 from stix2validator import validate_string
 from stix2validator.validator import FileValidationResults
@@ -74,6 +75,8 @@ def convert_controlled_vocabs_to_open_vocabs(new_obj, new_property_name, old_voc
 def strftime_with_appropriate_fractional_seconds(timestamp, milliseconds_only):
     if isinstance(timestamp, (text_type, binary_type)):
         timestamp = datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%fZ")
+    elif isinstance(timestamp, DateTime):
+        timestamp = timestamp.value
     if milliseconds_only:
         return timestamp.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
     else:

--- a/stix2elevator/utils.py
+++ b/stix2elevator/utils.py
@@ -4,7 +4,6 @@ from datetime import datetime
 import os
 import textwrap
 
-from cybox.common.properties import DateTime
 from six import binary_type, iteritems, text_type
 from stix2validator import validate_string
 from stix2validator.validator import FileValidationResults
@@ -75,8 +74,6 @@ def convert_controlled_vocabs_to_open_vocabs(new_obj, new_property_name, old_voc
 def strftime_with_appropriate_fractional_seconds(timestamp, milliseconds_only):
     if isinstance(timestamp, (text_type, binary_type)):
         timestamp = datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%fZ")
-    elif isinstance(timestamp, DateTime):
-        timestamp = timestamp.value
     if milliseconds_only:
         return timestamp.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
     else:


### PR DESCRIPTION
Elevating a CybOX Email object with a `DateTime` object causes the following error: `AttributeError: 'DateTime' object has no attribute 'strftime'`. This PR fixes the conversion of the date.

Example code to reproduce:
```
import datetime
from cybox.core import Observable
from cybox.objects.email_message_object import EmailMessage
from stix.core import STIXPackage
from stix2elevator import elevate
from stix2elevator.options import initialize_options

initialize_options()
e = EmailMessage()
e.from_ = "spammer@spam.com"
e.subject = "This is not spam"
e.date = datetime.datetime(2012, 1, 17, 8, 35, 6)
pkg = STIXPackage()
pkg.add(Observable(e))
elevate(pkg)
```

STIX 1.2 XML:
```
<stix:STIX_Package 
	xmlns:AddressObj="http://cybox.mitre.org/objects#AddressObject-2"
	xmlns:EmailMessageObj="http://cybox.mitre.org/objects#EmailMessageObject-2"
	xmlns:cyboxCommon="http://cybox.mitre.org/common-2"
	xmlns:stix="http://stix.mitre.org/stix-1"
	xmlns:cybox="http://cybox.mitre.org/cybox-2"
	xmlns:example="http://example.com"
	xmlns:xlink="http://www.w3.org/1999/xlink"
	xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
	xmlns:xs="http://www.w3.org/2001/XMLSchema"
	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
	 id="example:Package-6b617865-c980-4674-b71a-e58651ba0b68" version="1.2">
    <stix:Observables cybox_major_version="2" cybox_minor_version="1" cybox_update_version="0">
        <cybox:Observable id="example:Observable-9054c63a-dd92-49b2-907d-3dec35d212d8">
            <cybox:Object id="example:EmailMessage-99d918b9-e28c-44c6-ae0d-9f29a11807df">
                <cybox:Properties xsi:type="EmailMessageObj:EmailMessageObjectType">
                    <EmailMessageObj:Header>
                        <EmailMessageObj:From xsi:type="AddressObj:AddressObjectType" category="e-mail">
                            <AddressObj:Address_Value>spammer@spam.com</AddressObj:Address_Value>
                        </EmailMessageObj:From>
                        <EmailMessageObj:Subject>This is not spam</EmailMessageObj:Subject>
                        <EmailMessageObj:Date>2012-01-17T08:35:06</EmailMessageObj:Date>
                    </EmailMessageObj:Header>
                </cybox:Properties>
            </cybox:Object>
        </cybox:Observable>
    </stix:Observables>
</stix:STIX_Package>```