### PR TITLE
Fix process_information_source_for_sighting arguments

### DIFF
--- a/stix2elevator/convert_stix.py
+++ b/stix2elevator/convert_stix.py
@@ -383,11 +383,11 @@ def handle_sightings_observables(related_observables, bundle_instance, parent_ti
     return refs
 
 
-def process_information_source_for_sighting(sighting, sighting_instance, bundle_instance, parent_timestamp):
+def process_information_source_for_sighting(sighting, sighting_instance, bundle_instance):
     if sighting.source:
         information_source = sighting.source
         if information_source.identity is not None:
-            sighting_instance["where_sighted_refs"] = [get_identity_ref(information_source.identity, bundle_instance, parent_timestamp)]
+            sighting_instance["where_sighted_refs"] = [get_identity_ref(information_source.identity, bundle_instance)]
             if information_source.description:
                 process_description_and_short_description(sighting_instance, sighting)
             if information_source.references:


### PR DESCRIPTION
When processing a sighting with an information source, an error occurs because the wrong number of arguments are passed to the `process_information_source_for_sighting()` function. This fixes the function signature of `process_information_source_for_sighting()` and the call to `get_identify_ref()` inside of it, that also had an incorrect number of arguments being passed.

**Error:**
```
  File ".../cti-stix-elevator/stix2elevator/convert_stix.py", line 411, in handle_sighting
    process_information_source_for_sighting(sighting, sighting_instance, env)
TypeError: process_information_source_for_sighting() missing 1 required positional argument: 'parent_timestamp'
```

**Example code to reproduce:**
```
initialize_options()
pkg = STIXPackage()
ind = Indicator(title='Malicious site hosting downloader')
uri = URI('http://x4z9arb.cn/4712')
uri.condition = 'Equals'
ind.add_observable(Observable(uri))
info_source = InformationSource(identity=Identity(name="Charlie Tango"))
sighting = Sighting()
sighting.source = info_source
ind.sightings.append(sighting)
pkg.add(ind)
elevate(pkg)
```

**STIX 1.2 XML:**
```
<stix:STIX_Package 
	xmlns:URIObj="http://cybox.mitre.org/objects#URIObject-2"
	xmlns:indicator="http://stix.mitre.org/Indicator-2"
	xmlns:cyboxCommon="http://cybox.mitre.org/common-2"
	xmlns:stix="http://stix.mitre.org/stix-1"
	xmlns:stixCommon="http://stix.mitre.org/common-1"
	xmlns:cybox="http://cybox.mitre.org/cybox-2"
	xmlns:example="http://example.com"
	xmlns:xlink="http://www.w3.org/1999/xlink"
	xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
	xmlns:xs="http://www.w3.org/2001/XMLSchema"
	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
	 id="example:Package-99d2a5bf-7cf2-4e90-a402-ed1b08a5bcc5" version="1.2">
    <stix:Indicators>
        <stix:Indicator id="example:indicator-6737ec19-c598-4c15-929c-3a94fc1d5951" timestamp="2020-03-12T15:49:11.512807+00:00" xsi:type='indicator:IndicatorType'>
            <indicator:Title>Malicious site hosting downloader</indicator:Title>
            <indicator:Observable id="example:Observable-2a64c3d7-271a-4125-89cd-c84c6534fd85">
                <cybox:Object id="example:URI-157e60b4-184d-4705-966e-616f3d2f6e33">
                    <cybox:Properties xsi:type="URIObj:URIObjectType">
                        <URIObj:Value>http://x4z9arb.cn/4712</URIObj:Value>
                    </cybox:Properties>
                </cybox:Object>
            </indicator:Observable>
            <indicator:Sightings>
                <indicator:Sighting timestamp="2020-03-12T15:49:11.516590+00:00">
                    <indicator:Source>
                        <stixCommon:Identity>
                            <stixCommon:Name>Charlie Tango</stixCommon:Name>
                        </stixCommon:Identity>
                    </indicator:Source>
                </indicator:Sighting>
            </indicator:Sightings>
        </stix:Indicator>
    </stix:Indicators>
</stix:STIX_Package>
```