### PR TITLE
URI List Support

### DIFF
--- a/idioms-json-2.0-custom/indicator-for-malicious-url-list.json
+++ b/idioms-json-2.0-custom/indicator-for-malicious-url-list.json
@@ -1,0 +1,19 @@
+{
+    "id": "bundle--6dcfdedf-aa96-4c54-8b61-33d57bebc0f7",
+    "objects": [
+        {
+            "created": "2020-03-13T15:57:09.287Z",
+            "id": "indicator--e0321ab0-4547-4f94-83d3-3e594767dd4b",
+            "labels": [
+                "url-watchlist"
+            ],
+            "modified": "2020-03-13T15:57:09.287Z",
+            "name": "Indicator for URL Watchlist",
+            "pattern": "[url:value IN ('http://example.com/foo/malicious1.html', 'http://example.com/foo/malicious2.html', 'http://example.com/foo/malicious3.html')]",
+            "type": "indicator",
+            "valid_from": "2020-03-13T15:57:09.287696Z"
+        }
+    ],
+    "spec_version": "2.0",
+    "type": "bundle"
+}

--- a/idioms-json-2.0/indicator-for-malicious-url-list.json
+++ b/idioms-json-2.0/indicator-for-malicious-url-list.json
@@ -1,0 +1,19 @@
+{
+    "id": "bundle--6dcfdedf-aa96-4c54-8b61-33d57bebc0f7",
+    "objects": [
+        {
+            "created": "2020-03-13T15:57:09.287Z",
+            "id": "indicator--e0321ab0-4547-4f94-83d3-3e594767dd4b",
+            "labels": [
+                "url-watchlist"
+            ],
+            "modified": "2020-03-13T15:57:09.287Z",
+            "name": "Indicator for URL Watchlist",
+            "pattern": "[url:value IN ('http://example.com/foo/malicious1.html', 'http://example.com/foo/malicious2.html', 'http://example.com/foo/malicious3.html')]",
+            "type": "indicator",
+            "valid_from": "2020-03-13T15:57:09.287696Z"
+        }
+    ],
+    "spec_version": "2.0",
+    "type": "bundle"
+}

--- a/idioms-json-2.1-custom/indicator-for-malicious-url-list.json
+++ b/idioms-json-2.1-custom/indicator-for-malicious-url-list.json
@@ -1,0 +1,20 @@
+{
+    "id": "bundle--6dcfdedf-aa96-4c54-8b61-33d57bebc0f7",
+    "objects": [
+        {
+            "created": "2020-03-13T15:57:09.287Z",
+            "id": "indicator--e0321ab0-4547-4f94-83d3-3e594767dd4b",
+            "indicator_types": [
+                "url-watchlist"
+            ],
+            "modified": "2020-03-13T15:57:09.287Z",
+            "name": "Indicator for URL Watchlist",
+            "pattern": "[url:value IN ('http://example.com/foo/malicious1.html', 'http://example.com/foo/malicious2.html', 'http://example.com/foo/malicious3.html')]",
+            "pattern_type": "stix",
+            "spec_version": "2.1",
+            "type": "indicator",
+            "valid_from": "2020-03-13T15:57:09.287696Z"
+        }
+    ],
+    "type": "bundle"
+}

--- a/idioms-json-2.1/indicator-for-malicious-url-list.json
+++ b/idioms-json-2.1/indicator-for-malicious-url-list.json
@@ -1,0 +1,20 @@
+{
+    "id": "bundle--6dcfdedf-aa96-4c54-8b61-33d57bebc0f7",
+    "objects": [
+        {
+            "created": "2020-03-13T15:57:09.287Z",
+            "id": "indicator--e0321ab0-4547-4f94-83d3-3e594767dd4b",
+            "indicator_types": [
+                "url-watchlist"
+            ],
+            "modified": "2020-03-13T15:57:09.287Z",
+            "name": "Indicator for URL Watchlist",
+            "pattern": "[url:value IN ('http://example.com/foo/malicious1.html', 'http://example.com/foo/malicious2.html', 'http://example.com/foo/malicious3.html')]",
+            "pattern_type": "stix",
+            "spec_version": "2.1",
+            "type": "indicator",
+            "valid_from": "2020-03-13T15:57:09.287696Z"
+        }
+    ],
+    "type": "bundle"
+}

--- a/idioms-xml/indicator-for-malicious-url-list.xml
+++ b/idioms-xml/indicator-for-malicious-url-list.xml
@@ -1,0 +1,28 @@
+<stix:STIX_Package
+	xmlns:stixVocabs="http://stix.mitre.org/default_vocabularies-1"
+	xmlns:URIObj="http://cybox.mitre.org/objects#URIObject-2"
+	xmlns:stix="http://stix.mitre.org/stix-1"
+	xmlns:stixCommon="http://stix.mitre.org/common-1"
+	xmlns:cybox="http://cybox.mitre.org/cybox-2"
+	xmlns:cyboxCommon="http://cybox.mitre.org/common-2"
+	xmlns:indicator="http://stix.mitre.org/Indicator-2"
+	xmlns:example="http://example.com"
+	xmlns:xlink="http://www.w3.org/1999/xlink"
+	xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	 id="example:Package-6dcfdedf-aa96-4c54-8b61-33d57bebc0f7" version="1.2">
+    <stix:Indicators>
+        <stix:Indicator id="example:indicator-e0321ab0-4547-4f94-83d3-3e594767dd4b" timestamp="2020-03-13T15:57:09.287696+00:00" xsi:type='indicator:IndicatorType'>
+            <indicator:Title>Indicator for URL Watchlist</indicator:Title>
+            <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">URL Watchlist</indicator:Type>
+            <indicator:Observable id="example:Observable-141ab9cb-e50b-4e53-8432-0aa1bc16a50b">
+                <cybox:Object id="example:URI-10edcf76-1334-4942-9b8e-df47c651fe23">
+                    <cybox:Properties xsi:type="URIObj:URIObjectType">
+                        <URIObj:Value condition="Equals" apply_condition="ANY">http://example.com/foo/malicious1.html##comma##http://example.com/foo/malicious2.html##comma##http://example.com/foo/malicious3.html</URIObj:Value>
+                    </cybox:Properties>
+                </cybox:Object>
+            </indicator:Observable>
+        </stix:Indicator>
+    </stix:Indicators>
+</stix:STIX_Package>

--- a/stix2elevator/convert_pattern.py
+++ b/stix2elevator/convert_pattern.py
@@ -1026,7 +1026,10 @@ def convert_address_to_pattern(add):
 
 
 def convert_uri_to_pattern(uri):
-    return create_term("url:value", uri.value.condition, make_constant(uri.value.value.strip()))
+    if isinstance(uri.value.value, list):
+        return create_term("url:value", uri.value.condition, make_constant([val.strip() for val in uri.value.value]))
+    else:
+        return create_term("url:value", uri.value.condition, make_constant(uri.value.value.strip()))
 
 
 # NOTICE:  The format of these PROPERTIES is different than the others in this file!!!!!!


### PR DESCRIPTION
It's possible for a CybOX URI object's value to be a list. The elevator assumes it will always be a string, and this results in an error. This change adds support for a list and includes an idiom for testing.

**Error:**
```
  File ".../cti-stix-elevator/stix2elevator/convert_pattern.py", line 1029, in convert_uri_to_pattern
    return create_term("url:value", uri.value.condition, make_constant(uri.value.value.strip()))
AttributeError: 'list' object has no attribute 'strip'
```

**Example code to reproduce:**
```
from cybox.core import Observable
from cybox.objects.uri_object import URI
from stix.core import STIXPackage
from stix.indicator import Indicator
from stix2elevator import elevate
from stix2elevator.options import initialize_options

initialize_options()
pkg = STIXPackage()
uri = URI([
    'http://example.com/foo/malicious1.html',
    'http://example.com/foo/malicious2.html',
    'http://example.com/foo/malicious3.html'
])
uri.value.condition = "Equals"
ind = Indicator(title='Indicator for URL Watchlist')
ind.add_indicator_type('URL Watchlist')
ind.add_observable(Observable(uri))
pkg.add(ind)
elevate(pkg)
```