### PR TITLE
Elevator Handling

### DIFF
--- a/idioms-json-2.0-custom/registry-with-user.json
+++ b/idioms-json-2.0-custom/registry-with-user.json
@@ -12,6 +12,7 @@
                 "0": {
                     "creator_user_ref": "1",
                     "key": "HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\User Shell Folders",
+                    "modified_time": "2013-02-19T00:00:00.000000Z",
                     "type": "windows-registry-key"
                 },
                 "1": {

--- a/idioms-json-2.0-custom/registry-with-user.json
+++ b/idioms-json-2.0-custom/registry-with-user.json
@@ -12,7 +12,7 @@
                 "0": {
                     "creator_user_ref": "1",
                     "key": "HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\User Shell Folders",
-                    "modified_time": "2013-02-19T00:00:00.000000Z",
+                    "modified": "2013-02-19T00:00:00.000000Z",
                     "type": "windows-registry-key"
                 },
                 "1": {

--- a/idioms-json-2.0/registry-with-user.json
+++ b/idioms-json-2.0/registry-with-user.json
@@ -12,6 +12,7 @@
                 "0": {
                     "creator_user_ref": "1",
                     "key": "HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\User Shell Folders",
+                    "modified_time": "2013-02-19T00:00:00.000000Z",
                     "type": "windows-registry-key"
                 },
                 "1": {

--- a/idioms-json-2.0/registry-with-user.json
+++ b/idioms-json-2.0/registry-with-user.json
@@ -12,7 +12,7 @@
                 "0": {
                     "creator_user_ref": "1",
                     "key": "HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\User Shell Folders",
-                    "modified_time": "2013-02-19T00:00:00.000000Z",
+                    "modified": "2013-02-19T00:00:00.000000Z",
                     "type": "windows-registry-key"
                 },
                 "1": {

--- a/idioms-json-2.1-custom/registry_with_user.json
+++ b/idioms-json-2.1-custom/registry_with_user.json
@@ -5,6 +5,7 @@
             "creator_user_ref": "user-account--bde0514f-3926-5535-a23e-030fc14d15f8",
             "id": "windows-registry-key--d37b122f-81f4-5b22-b13e-f3cb62e25a30",
             "key": "HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\User Shell Folders",
+            "modified_time": "2013-02-19T00:00:00.000000Z",
             "type": "windows-registry-key"
         },
         {

--- a/idioms-json-2.1/registry_with_user.json
+++ b/idioms-json-2.1/registry_with_user.json
@@ -5,6 +5,7 @@
             "creator_user_ref": "user-account--bde0514f-3926-5535-a23e-030fc14d15f8",
             "id": "windows-registry-key--d37b122f-81f4-5b22-b13e-f3cb62e25a30",
             "key": "HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\User Shell Folders",
+            "modified_time": "2013-02-19T00:00:00.000000Z",
             "type": "windows-registry-key"
         },
         {

--- a/idioms-xml/registry-with-user.xml
+++ b/idioms-xml/registry-with-user.xml
@@ -14,6 +14,7 @@
                 <cybox:Properties xsi:type="WinRegistryKeyObj:WindowsRegistryKeyObjectType">
                     <WinRegistryKeyObj:Key>HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders</WinRegistryKeyObj:Key>
                     <WinRegistryKeyObj:Creator_Username>Fred</WinRegistryKeyObj:Creator_Username>
+                    <WinRegistryKeyObj:Modified_Time>2013-02-19T00:00:00Z</WinRegistryKeyObj:Modified_Time>
                 </cybox:Properties>
             </cybox:Object>
         </cybox:Observable>

--- a/stix2elevator/__init__.py
+++ b/stix2elevator/__init__.py
@@ -79,14 +79,14 @@ def elevate(stix_package):
             io = BytesIO(stix_package.to_xml())
             container = stixmarx.parse(io)
         elif isinstance(stix_package, text_type):
-            if stix_package.endswith(text_type(".xml")) or os.path.isfile(stix_package):
+            if stix_package.endswith(".xml") or os.path.isfile(stix_package):
                 # a path-like string was passed
                 fn = stix_package
             else:
                 stix_package = StringIO(stix_package)
             container = stixmarx.parse(stix_package)
         elif isinstance(stix_package, binary_type):
-            if stix_package.endswith(binary_type(".xml")) or os.path.isfile(stix_package):
+            if stix_package.endswith(b".xml") or os.path.isfile(stix_package):
                 # a path-like string was passed
                 fn = stix_package
             else:

--- a/stix2elevator/__init__.py
+++ b/stix2elevator/__init__.py
@@ -79,14 +79,14 @@ def elevate(stix_package):
             io = BytesIO(stix_package.to_xml())
             container = stixmarx.parse(io)
         elif isinstance(stix_package, text_type):
-            if stix_package.endswith(".xml") or os.path.isfile(stix_package):
+            if stix_package.endswith(text_type(".xml")) or os.path.isfile(stix_package):
                 # a path-like string was passed
                 fn = stix_package
             else:
                 stix_package = StringIO(stix_package)
             container = stixmarx.parse(stix_package)
         elif isinstance(stix_package, binary_type):
-            if stix_package.endswith(".xml") or os.path.isfile(stix_package):
+            if stix_package.endswith(binary_type(".xml")) or os.path.isfile(stix_package):
                 # a path-like string was passed
                 fn = stix_package
             else:

--- a/stix2elevator/convert_cybox.py
+++ b/stix2elevator/convert_cybox.py
@@ -252,7 +252,7 @@ def convert_hashes(hashes):
             hash_type = text_type(h.type_).lower()
         else:
             hash_type = text_type(h.type_)
-        hash_dict[hash_type] = hash_value
+        hash_dict[hash_type] = hash_value.value
     return hash_dict
 
 
@@ -653,9 +653,9 @@ def convert_registry_key(reg_key, obj1x_id):
             cybox_reg["values"].append(reg_value)
     if reg_key.modified_time:
         if get_option_value("spec_version") == "2.0":
-            cybox_reg["modified"] = convert_timestamp_to_string(reg_key.modified_time)
+            cybox_reg["modified"] = convert_timestamp_to_string(reg_key.modified_time.value)
         else:
-            cybox_reg["modified_time"] = convert_timestamp_to_string(reg_key.modified_time)
+            cybox_reg["modified_time"] = convert_timestamp_to_string(reg_key.modified_time.value)
     finish_sco(cybox_reg, obj1x_id)
     if reg_key.creator_username:
         user_obj = create_base_sco("user-account", {"user_id": text_type(reg_key.creator_username)})

--- a/stix2elevator/test/test_main.py
+++ b/stix2elevator/test/test_main.py
@@ -105,8 +105,8 @@ def test_elevate_with_binary_string():
     xml_idioms_dir = find_dir(directory, "idioms-xml")
     archive_file = os.path.join(xml_idioms_dir, "141-TLP-marking-structures.xml")
 
-    with io.open(archive_file, mode="r", encoding="utf-8") as f:
-        input_stix = f.read().encode("utf-8")
+    with io.open(archive_file, mode="rb") as f:
+        input_stix = f.read()
 
     json_result = elevate(input_stix)
     assert json_result


### PR DESCRIPTION
better handling for file elevate -- file or string support
convert_cybox.py fix hash_value, fix datetime

The better handling for the elevator will still print the problematic area if further fixes are needed, but no longer will the tool fail-hard. Instead the elevate() function will return None.

closes #207 
closes #212 
closes #211 
closes #159