### PR TITLE
Fix related COAs handle_relationship_to_refs call

### DIFF
--- a/stix2elevator/convert_stix.py
+++ b/stix2elevator/convert_stix.py
@@ -749,9 +749,9 @@ def convert_course_of_action(coa, env):
     handle_missing_statement_properties(coa_instance, coa.impact, "impact")
     handle_missing_statement_properties(coa_instance, coa.cost, "cost")
     handle_missing_statement_properties(coa_instance, coa.efficacy, "efficacy")
-    coa_created_by_ref = process_information_source(coa.information_source,
-                                                    coa_instance,
-                                                    new_env)
+    new_env.add_to_env(created_by_ref=process_information_source(coa.information_source,
+                                                                 coa_instance,
+                                                                 new_env))
     # process information source before any relationships
     if coa.related_coas:
         info("All 'associated coas' relationships of %s are assumed to not represent STIX 1.2 versioning", 710, coa.id_)

--- a/stix2elevator/convert_stix.py
+++ b/stix2elevator/convert_stix.py
@@ -756,7 +756,7 @@ def convert_course_of_action(coa, env):
     if coa.related_coas:
         info("All 'associated coas' relationships of %s are assumed to not represent STIX 1.2 versioning", 710, coa.id_)
         handle_relationship_to_refs(coa.related_coas, coa_instance["id"], new_env,
-                                    coa_created_by_ref, "related-to")
+                                    "related-to")
     finish_basic_object(coa.id_, coa_instance, env, coa)
     return coa_instance
 


### PR DESCRIPTION
With related COAs, the call to `handle_relationship_to_refs` had an extra, invalid argument.

Error:
```
  File ".../cti-stix-elevator/stix2elevator/convert_stix.py", line 759, in convert_course_of_action
    coa_created_by_ref, "related-to")
TypeError: handle_relationship_to_refs() takes 4 positional arguments but 5 were given
```

Example STIX:
```
<stix:STIX_Package 
	xmlns:stixCommon="http://stix.mitre.org/common-1"
	xmlns:stix="http://stix.mitre.org/stix-1"
	xmlns:coa="http://stix.mitre.org/CourseOfAction-1"
	xmlns:example="http://example.com"
	xmlns:xlink="http://www.w3.org/1999/xlink"
	xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
	xmlns:xs="http://www.w3.org/2001/XMLSchema"
	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
	 id="example:Package-a7f58ffb-5c4e-4481-8309-b2abee6c135e" version="1.2">
    <stix:Courses_Of_Action>
        <stix:Course_Of_Action id="example:coa-73711c1d-d30b-46b6-b5d8-3c39e8caacd3" timestamp="2020-02-21T17:14:18.235881+00:00" xsi:type='coa:CourseOfActionType'>
            <coa:Title>CoA 1</coa:Title>
        </stix:Course_Of_Action>
        <stix:Course_Of_Action id="example:coa-040e9570-04c6-4fae-8e22-0a01428a1bec" timestamp="2020-02-21T17:14:14.095955+00:00" xsi:type='coa:CourseOfActionType'>
            <coa:Title>CoA 2</coa:Title>
            <coa:Related_COAs>
                <coa:Related_COA>
                    <stixCommon:Course_Of_Action idref="example:coa-73711c1d-d30b-46b6-b5d8-3c39e8caacd3" xsi:type='coa:CourseOfActionType'/>
                </coa:Related_COA>
            </coa:Related_COAs>
        </stix:Course_Of_Action>
    </stix:Courses_Of_Action>
</stix:STIX_Package>
```