### PR TITLE
Handle tuple when converting http client request

### DIFF
--- a/stix2elevator/convert_cybox.py
+++ b/stix2elevator/convert_cybox.py
@@ -1250,7 +1250,7 @@ def convert_http_session(session, obj1x_id):
             warn("HTTPServerResponse type is not supported in STIX 2.x", 429)
         if len(requests) >= 1:
             cybox_traffic = create_base_sco("network-traffic")
-            cybox_traffic["extensions"] = {"http-request-ext": convert_http_client_request(requests[0])}
+            cybox_traffic["extensions"] = {"http-request-ext": convert_http_client_request(requests[0])[0]}
             if len(requests) > 1:
                 warn("Only HTTP_Request_Response used for http-request-ext, using first value", 512)
             finish_sco(cybox_traffic, obj1x_id)


### PR DESCRIPTION
Fixed an issue when that was causing HTTPSession Cybox objects to not validate when converted because the `http-request-ext` is a list (e.g. `{'http-request-ext': [{'request_header': {'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:25.0) Gecko/20100101 Firefox/25.0'}}, None]}`).

Error:
```
File ".../stix2validator/v21/shoulds.py", line 697, in custom_observable_properties_prefix_strict
    not CUSTOM_PROPERTY_PREFIX_RE.match(ext_prop)):
TypeError: expected string or bytes-like object
```

It looks like `convert_http_session()` was not updated to handle the tuple returned by `convert_http_client_request()` in b97dc6a.

Example XML:
```
<stix:STIX_Package 
	xmlns:HTTPSessionObj="http://cybox.mitre.org/objects#HTTPSessionObject-2"
	xmlns:cyboxCommon="http://cybox.mitre.org/common-2"
	xmlns:stix="http://stix.mitre.org/stix-1"
	xmlns:cybox="http://cybox.mitre.org/cybox-2"
	xmlns:example="http://example.com"
	xmlns:xlink="http://www.w3.org/1999/xlink"
	xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
	xmlns:xs="http://www.w3.org/2001/XMLSchema"
	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
	 id="example:Package-5d881a21-d889-49a5-af07-766258a66152" version="1.2">
    <stix:Observables cybox_major_version="2" cybox_minor_version="1" cybox_update_version="0">
        <cybox:Observable id="example:Observable-fca4bd90-906e-4566-97eb-1afd6bc50043">
            <cybox:Object id="example:HTTPSession-982d94c6-0e4f-482c-9014-9969aa7e9083">
                <cybox:Properties xsi:type="HTTPSessionObj:HTTPSessionObjectType">
                    <HTTPSessionObj:HTTP_Request_Response>
                        <HTTPSessionObj:HTTP_Client_Request>
                            <HTTPSessionObj:HTTP_Request_Header>
                                <HTTPSessionObj:Parsed_Header>
                                    <HTTPSessionObj:User_Agent>Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:25.0) Gecko/20100101 Firefox/25.0</HTTPSessionObj:User_Agent>
                                </HTTPSessionObj:Parsed_Header>
                            </HTTPSessionObj:HTTP_Request_Header>
                        </HTTPSessionObj:HTTP_Client_Request>
                        <HTTPSessionObj:HTTP_Server_Response>
                            <HTTPSessionObj:HTTP_Message_Body>
                                <HTTPSessionObj:Length>69</HTTPSessionObj:Length>
                                <HTTPSessionObj:Message_Body>&lt;html&gt;&lt;title&gt;An HTML page&lt;/title&gt;&lt;body&gt;&lt;p&gt;Body text&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</HTTPSessionObj:Message_Body>
                            </HTTPSessionObj:HTTP_Message_Body>
                        </HTTPSessionObj:HTTP_Server_Response>
                    </HTTPSessionObj:HTTP_Request_Response>
                </cybox:Properties>
            </cybox:Object>
        </cybox:Observable>
    </stix:Observables>
</stix:STIX_Package>
```