### PR TITLE
Adding Python 3.9 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 install:
   - pip install -U pip setuptools
   - pip install tox-travis

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,8 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Development Status :: 2 - Pre-Alpha',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37,38}-stix{20,21}-missing-policy{-description,-custom},style,isort-check,packaging
+envlist = py{35,36,37,38,39}-stix{20,21}-missing-policy{-description,-custom},style,isort-check,packaging
 
 [testenv]
 deps =
@@ -50,7 +50,8 @@ python =
   3.5: py35
   3.6: py36
   3.7: py37
-  3.8: py38, style, isort-check, packaging
+  3.8: py38
+  3.9: py39, style, isort-check, packaging
 
 [travis:env]
 VERSION =


### PR DESCRIPTION
Python 3.9 has been released in October 2020 and it is expected that security updates will be released until approximately October 2025.

[See PEP 596 -- Python 3.9 Release Schedule](https://www.python.org/dev/peps/pep-0596/#id7)