### PR TITLE
stepper now handles 2.1 extensions

### DIFF
--- a/idioms-json-2.0-custom/file-hash-reputation.json
+++ b/idioms-json-2.0-custom/file-hash-reputation.json
@@ -12,7 +12,7 @@
             "pattern": "[file:hashes.'SHA-256' = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855']",
             "type": "indicator",
             "valid_from": "2015-07-20T19:52:13.853585Z",
-            "x_elevator_confidence": "75"
+            "x_elevator_confidence": 75
         }
     ],
     "spec_version": "2.0",

--- a/idioms-json-2.0-custom/incident-malware.json
+++ b/idioms-json-2.0-custom/incident-malware.json
@@ -3,7 +3,7 @@
     "objects": [
         {
             "created": "2014-05-08T09:00:00.000Z",
-            "id": "identity--6aedbecd-7323-4308-9cac-8fc71b9e10d2",
+            "id": "identity--fe25732c-1d92-4642-9f67-54f627c4bbc5",
             "identity_class": "unknown",
             "modified": "2014-05-08T09:00:00.000Z",
             "name": "Fred",
@@ -11,23 +11,23 @@
         },
         {
             "created": "2014-05-08T09:00:00.000Z",
-            "id": "identity--f854887d-9e74-4e95-a2a0-f79af678768e",
+            "id": "identity--1a10e908-6c64-424b-b196-220790ec230f",
             "identity_class": "unknown",
             "modified": "2014-05-08T09:00:00.000Z",
             "name": "Barney",
             "type": "identity"
         },
         {
+            "contacts": [
+                "identity--fe25732c-1d92-4642-9f67-54f627c4bbc5",
+                "identity--1a10e908-6c64-424b-b196-220790ec230f"
+            ],
             "created": "2014-05-08T09:00:00.000Z",
             "id": "x-elevator-incident--1b75ee8f-44d6-819a-d729-09ab52c91fdb",
             "modified": "2014-05-08T09:00:00.000Z",
             "name": "Detected Poison Ivy beaconing through perimeter firewalls",
-            "type": "x-elevator-incident",
-            "x_elevator_contacts": [
-                "identity--6aedbecd-7323-4308-9cac-8fc71b9e10d2",
-                "identity--f854887d-9e74-4e95-a2a0-f79af678768e"
-            ],
-            "x_elevator_status": "New"
+            "status": "New",
+            "type": "x-elevator-incident"
         },
         {
             "created": "2014-05-08T09:00:00.000Z",
@@ -43,7 +43,7 @@
         {
             "created": "2014-05-08T09:00:00.000Z",
             "description": "Uses Malware",
-            "id": "relationship--dfc77494-4990-4d86-a4fc-0a20963fe6e2",
+            "id": "relationship--71463605-b468-41b7-8c82-11375901b2c2",
             "modified": "2014-05-08T09:00:00.000Z",
             "relationship_type": "related-to",
             "source_ref": "x-elevator-incident--1b75ee8f-44d6-819a-d729-09ab52c91fdb",

--- a/idioms-json-2.0-valid/block-network-traffic.json
+++ b/idioms-json-2.0-valid/block-network-traffic.json
@@ -1,18 +1,25 @@
 {
-  "id": "bundle--495c4c04-b5d8-11e3-b7bb-000c29789db9",
-  "objects": [
-    {
-      "created": "2017-01-27T13:49:41.298Z",
-      "description": "\n\nSTAGE:\n\tResponse\n\nOBJECTIVE: Block communication between the PIVY agents and the C2 Server\n\nCONFIDENCE: High\n\nIMPACT:LowThis IP address is not used for legitimate hosting so there should be no operational impact.\n\nCOST:Low\n\nEFFICACY:High",
-      "id": "course-of-action--495c9b28-b5d8-11e3-b7bb-000c29789db9",
-      "labels": [
-        "perimeter-blocking"
-      ],
-      "modified": "2017-01-27T13:49:41.298Z",
-      "name": "Block traffic to PIVY C2 Server (10.10.10.10)",
-      "type": "course-of-action"
-    }
-  ],
-  "spec_version": "2.0",
-  "type": "bundle"
+    "id": "bundle--495c4c04-b5d8-11e3-b7bb-000c29789db9",
+    "objects": [
+        {
+            "created": "2019-10-04T13:10:29.813Z",
+            "id": "course-of-action--495c9b28-b5d8-11e3-b7bb-000c29789db9",
+            "labels": [
+                "perimeter-blocking"
+            ],
+            "modified": "2019-10-04T13:10:29.813Z",
+            "name": "Block traffic to PIVY C2 Server (10.10.10.10)",
+            "type": "course-of-action",
+            "x_elevator_cost": "Low",
+            "x_elevator_efficacy": "High",
+            "x_elevator_impact": "Low",
+            "x_elevator_impact_description": "This IP address is not used for legitimate hosting so there should be no operational impact.",
+            "x_elevator_objective": "Block communication between the PIVY agents and the C2 Server",
+            "x_elevator_objective_confidence": "High",
+            "x_elevator_parameter_expression": "ipv4-addr:value = '10.10.10.10'",
+            "x_elevator_stage": "Response"
+        }
+    ],
+    "spec_version": "2.0",
+    "type": "bundle"
 }

--- a/idioms-json-2.0-valid/campaign-v-actors.json
+++ b/idioms-json-2.0-valid/campaign-v-actors.json
@@ -1,76 +1,100 @@
 {
-  "id": "bundle--81810123-b298-40f6-a4e7-186efcd07670",
-  "objects": [
-    {
-      "created": "2014-08-08T15:50:10.983Z",
-      "goals": [
+    "id": "bundle--81810123-b298-40f6-a4e7-186efcd07670",
+    "objects": [
+        {
+            "created": "2014-08-08T15:50:10.983Z",
+            "id": "identity--2d1c6ab3-5e4e-48ac-a32b-f0c01c2836a8",
+            "identity_class": "unknown",
+            "modified": "2014-08-08T15:50:10.983Z",
+            "name": "Victim Targeting: Customer PII and Financial Data",
+            "type": "identity",
+            "x_elevator_targeted_information": [
+                "Information Assets - Financial Data"
+            ]
+        },
+        {
+            "created": "2014-08-08T15:50:10.983Z",
+            "goals": [
                 "Theft",
                 "Theft - Theft of Proprietary Information"
             ],
-      "id": "threat-actor--56f3f0db-b5d5-431c-ae56-c18f02caf500",
-      "labels": [
-        "unknown"
-      ],
-      "modified": "2014-08-08T15:50:10.983Z",
-      "name": "People behind the intrusion",
-      "sophistication": "unknown",
-      "type": "threat-actor"
-    },
-    {
-      "aliases": [
-        "Charming Kittens",
-        "NewsBeef"
-      ],
-      "created": "2014-08-08T15:50:10.983Z",
-      "description": "Fred\n\nINFORMATION SOURCE ROLE: Aggregator\n\nINFORMATION SOURCE ROLE: Initial Author",
-      "external_references": [
+            "id": "threat-actor--56f3f0db-b5d5-431c-ae56-c18f02caf500",
+            "labels": [
+                "unknown"
+            ],
+            "modified": "2014-08-08T15:50:10.983Z",
+            "name": "People behind the intrusion",
+            "sophistication": "unknown",
+            "type": "threat-actor"
+        },
         {
-          "source_name": "unknown",
-          "url": "http://foo.com/bar"
+            "aliases": [
+                "Charming Kittens",
+                "NewsBeef"
+            ],
+            "created": "2014-08-08T15:50:10.983Z",
+            "description": "Fred",
+            "external_references": [
+                {
+                    "source_name": "unknown",
+                    "url": "http://foo.com/bar"
+                }
+            ],
+            "id": "campaign--e5268b6e-4931-42f1-b379-87f48eb41b1e",
+            "modified": "2014-08-08T15:50:10.983Z",
+            "name": "Compromise of ATM Machines",
+            "type": "campaign",
+            "x_elevator_information_source_roles": [
+                "Aggregator",
+                "Initial Author"
+            ]
+        },
+        {
+            "created": "2014-08-08T15:50:10.983Z",
+            "id": "relationship--c6ad8a94-edd3-4625-b5b3-24061c615a4b",
+            "modified": "2014-08-08T15:50:10.983Z",
+            "relationship_type": "targets",
+            "source_ref": "campaign--e5268b6e-4931-42f1-b379-87f48eb41b1e",
+            "target_ref": "identity--2d1c6ab3-5e4e-48ac-a32b-f0c01c2836a8",
+            "type": "relationship"
+        },
+        {
+            "created": "2014-08-08T15:50:10.983Z",
+            "id": "relationship--5dcfc21e-c88c-4a3b-b68a-9d207995b0c8",
+            "modified": "2014-08-08T15:50:10.983Z",
+            "relationship_type": "attributed-to",
+            "source_ref": "incident--229ab6ba-0eb2-415b-bdf2-079e6b42f51e",
+            "target_ref": "campaign--e5268b6e-4931-42f1-b379-87f48eb41b1e",
+            "type": "relationship"
+        },
+        {
+            "created": "2014-08-08T15:50:10.983Z",
+            "id": "relationship--66602cba-bf53-4d70-a8c3-83f089f6b693",
+            "modified": "2014-08-08T15:50:10.983Z",
+            "relationship_type": "attributed-to",
+            "source_ref": "incident--517cf274-038d-4ed4-a3ec-3ac18ad9db8a",
+            "target_ref": "campaign--e5268b6e-4931-42f1-b379-87f48eb41b1e",
+            "type": "relationship"
+        },
+        {
+            "created": "2014-08-08T15:50:10.983Z",
+            "id": "relationship--7611b8f0-5869-495f-9a97-ff5b81d95d03",
+            "modified": "2014-08-08T15:50:10.983Z",
+            "relationship_type": "attributed-to",
+            "source_ref": "incident--7d8cf96f-91cb-42d0-a1e0-bfa38ea08621",
+            "target_ref": "campaign--e5268b6e-4931-42f1-b379-87f48eb41b1e",
+            "type": "relationship"
+        },
+        {
+            "created": "2014-08-08T15:50:10.983Z",
+            "id": "relationship--6a592f33-f088-4211-860a-9121bd5059b6",
+            "modified": "2014-08-08T15:50:10.983Z",
+            "relationship_type": "attributed-to",
+            "source_ref": "campaign--e5268b6e-4931-42f1-b379-87f48eb41b1e",
+            "target_ref": "threat-actor--56f3f0db-b5d5-431c-ae56-c18f02caf500",
+            "type": "relationship"
         }
-      ],
-      "id": "campaign--e5268b6e-4931-42f1-b379-87f48eb41b1e",
-      "modified": "2014-08-08T15:50:10.983Z",
-      "name": "Compromise of ATM Machines",
-      "type": "campaign"
-    },
-    {
-      "created": "2014-08-08T15:50:10.983Z",
-      "id": "relationship--2ae13256-e6bb-4960-903a-63683c1df05a",
-      "modified": "2014-08-08T15:50:10.983Z",
-      "relationship_type": "attributed-to",
-      "source_ref": "incident--229ab6ba-0eb2-415b-bdf2-079e6b42f51e",
-      "target_ref": "campaign--e5268b6e-4931-42f1-b379-87f48eb41b1e",
-      "type": "relationship"
-    },
-    {
-      "created": "2014-08-08T15:50:10.983Z",
-      "id": "relationship--55662552-faf8-43b5-8a25-18a639c748ce",
-      "modified": "2014-08-08T15:50:10.983Z",
-      "relationship_type": "attributed-to",
-      "source_ref": "incident--517cf274-038d-4ed4-a3ec-3ac18ad9db8a",
-      "target_ref": "campaign--e5268b6e-4931-42f1-b379-87f48eb41b1e",
-      "type": "relationship"
-    },
-    {
-      "created": "2014-08-08T15:50:10.983Z",
-      "id": "relationship--1cec8c59-4d36-4f70-ba38-d800262f396d",
-      "modified": "2014-08-08T15:50:10.983Z",
-      "relationship_type": "attributed-to",
-      "source_ref": "incident--7d8cf96f-91cb-42d0-a1e0-bfa38ea08621",
-      "target_ref": "campaign--e5268b6e-4931-42f1-b379-87f48eb41b1e",
-      "type": "relationship"
-    },
-    {
-      "created": "2014-08-08T15:50:10.983Z",
-      "id": "relationship--3dcf59c3-30e3-4aa5-9c05-2cbffcee5922",
-      "modified": "2014-08-08T15:50:10.983Z",
-      "relationship_type": "attributed-to",
-      "source_ref": "campaign--e5268b6e-4931-42f1-b379-87f48eb41b1e",
-      "target_ref": "threat-actor--56f3f0db-b5d5-431c-ae56-c18f02caf500",
-      "type": "relationship"
-    }
-  ],
-  "spec_version": "2.0",
-  "type": "bundle"
+    ],
+    "spec_version": "2.0",
+    "type": "bundle"
 }

--- a/idioms-json-2.0-valid/custom_object.json
+++ b/idioms-json-2.0-valid/custom_object.json
@@ -1,0 +1,58 @@
+{
+    "id": "bundle--cad0c65f-3415-4ec6-84df-c01e427ec3b6",
+    "objects": [
+        {
+            "created": "2015-07-31T11:24:39.090Z",
+            "id": "course-of-action--3dbfccad-1fbb-4e9f-8307-f2d1a5c651cc",
+            "labels": [
+                "perimeter-blocking"
+            ],
+            "modified": "2015-07-31T11:24:39.090Z",
+            "name": "Block outbound traffic",
+            "type": "course-of-action",
+            "x_elevator_impact": "Medium",
+            "x_elevator_impact_description": "Some description about the indicator.",
+            "x_elevator_objective": "Block outbound traffic",
+            "x_elevator_objective_confidence": "High",
+            "x_elevator_stage": "Response"
+        },
+        {
+            "created": "2015-07-31T11:24:39.090Z",
+            "id": "indicator--2cb76e88-2734-4a6c-a28c-52ae05f627be",
+            "labels": [
+                "ftp"
+            ],
+            "modified": "2015-07-31T11:24:39.090Z",
+            "pattern": "[x-elevator-fooz:ftp_command MATCHES 'fp[a-zA-Z0-9]{44}\\\\.bin']",
+            "type": "indicator",
+            "valid_from": "2015-07-31T11:24:39.090000Z",
+            "x_elevator_likely_impact": "Medium"
+        },
+        {
+            "created": "2015-07-31T11:24:39.090Z",
+            "id": "relationship--b7e4e7c3-36b6-4e93-bc47-e6e65fc21168",
+            "modified": "2015-07-31T11:24:39.090Z",
+            "relationship_type": "investigates",
+            "source_ref": "course-of-action--3dbfccad-1fbb-4e9f-8307-f2d1a5c651cc",
+            "target_ref": "indicator--2cb76e88-2734-4a6c-a28c-52ae05f627be",
+            "type": "relationship"
+        },
+        {
+            "created": "2015-07-31T11:24:39.090Z",
+            "first_observed": "2015-07-31T11:24:39.090Z",
+            "id": "observed-data--b6a16349-c7ae-463e-9b74-8fd81efb14b7",
+            "last_observed": "2015-07-31T11:24:39.090Z",
+            "modified": "2015-07-31T11:24:39.090Z",
+            "number_observed": 1,
+            "objects": {
+                "0": {
+                    "ftp_command": "fpuwe8bmsD56ns.bin",
+                    "type": "x-elevator-fooz"
+                }
+            },
+            "type": "observed-data"
+        }
+    ],
+    "spec_version": "2.0",
+    "type": "bundle"
+}

--- a/idioms-json-2.0-valid/cve-in-exploit-target.json
+++ b/idioms-json-2.0-valid/cve-in-exploit-target.json
@@ -1,21 +1,26 @@
 {
-  "id": "bundle--0196d980-60d9-4717-b7c5-bf7bc27a35d4",
-  "objects": [
-    {
-      "created": "2014-05-08T09:00:00.000Z",
-      "description": "\n\nSOURCE:\n\tMITRE\n\nDISCOVERED_DATETIME:\n\t2013-09-18T06:06:47.000000Z",
-      "external_references": [
+    "id": "bundle--0196d980-60d9-4717-b7c5-bf7bc27a35d4",
+    "objects": [
         {
-          "external_id": "CVE-2013-3893",
-          "source_name": "cve"
+            "created": "2014-05-08T09:00:00.000Z",
+            "external_references": [
+                {
+                    "external_id": "CVE-2013-3893",
+                    "source_name": "cve"
+                },
+                {
+                    "source_name": "internet_resource",
+                    "url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-4878"
+                }
+            ],
+            "id": "vulnerability--abc80d31-5d22-4f07-b497-afba8e936f8f",
+            "modified": "2014-05-08T09:00:00.000Z",
+            "name": "Javascript vulnerability in MSIE 6-11",
+            "type": "vulnerability",
+            "x_elevator_discovered_datetime": "2013-09-18T06:06:47.000000Z",
+            "x_elevator_source": "MITRE"
         }
-      ],
-      "id": "vulnerability--b4b14336-9743-40c8-a070-b205531ddbc0",
-      "modified": "2014-05-08T09:00:00.000Z",
-      "name": "Javascript vulnerability in MSIE 6-11",
-      "type": "vulnerability"
-    }
-  ],
-  "spec_version": "2.0",
-  "type": "bundle"
+    ],
+    "spec_version": "2.0",
+    "type": "bundle"
 }

--- a/idioms-json-2.0-valid/file-and-directory.json
+++ b/idioms-json-2.0-valid/file-and-directory.json
@@ -22,7 +22,7 @@
           "type": "directory"
         },
         "2": {
-            "type": "x-windows-hook",
+            "type": "x-elevator-windows-hook",
             "win-hook-type": "WH_KEYBOARD_LL"
         }
       },

--- a/idioms-json-2.0-valid/file-hash-reputation.json
+++ b/idioms-json-2.0-valid/file-hash-reputation.json
@@ -1,20 +1,20 @@
 {
-  "id": "bundle--bc2955f8-f1bb-4f02-b2ed-339d7daf6d75",
-  "objects": [
-    {
-      "created": "2015-07-20T19:52:13.853Z",
-      "description": "\n\nCONFIDENCE: 75",
-      "id": "indicator--14975dea-86cd-4211-a5f8-9c2e4daab69a",
-      "labels": [
-        "file-hash-watchlist"
-      ],
-      "modified": "2015-07-20T19:52:13.853Z",
-      "name": "File Reputation for SHA256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "pattern": "[file:hashes.'SHA-256' = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855']",
-      "type": "indicator",
-      "valid_from": "2015-07-20T19:52:13.853585Z"
-    }
-  ],
-  "spec_version": "2.0",
-  "type": "bundle"
+    "id": "bundle--bc2955f8-f1bb-4f02-b2ed-339d7daf6d75",
+    "objects": [
+        {
+            "created": "2015-07-20T19:52:13.853Z",
+            "id": "indicator--14975dea-86cd-4211-a5f8-9c2e4daab69a",
+            "labels": [
+                "file-hash-watchlist"
+            ],
+            "modified": "2015-07-20T19:52:13.853Z",
+            "name": "File Reputation for SHA256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "pattern": "[file:hashes.'SHA-256' = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855']",
+            "type": "indicator",
+            "valid_from": "2015-07-20T19:52:13.853585Z",
+            "x_elevator_confidence": 75
+        }
+    ],
+    "spec_version": "2.0",
+    "type": "bundle"
 }

--- a/idioms-json-2.0-valid/fix-embedded-relationship-example.json
+++ b/idioms-json-2.0-valid/fix-embedded-relationship-example.json
@@ -1,94 +1,94 @@
 {
-  "id": "bundle--161f8ade-b67d-11e3-b8af-f01faf20d111",
-  "objects": [
-    {
-      "created": "2017-01-27T13:49:53.872Z",
-      "id": "identity--4ec4d0a2-80e3-11e6-ae22-56b6b6499611",
-      "identity_class": "unknown",
-      "modified": "2017-01-27T13:49:53.872Z",
-      "name": "Emmanuelle",
-      "type": "identity"
-    },
-    {
-      "created": "2017-01-27T13:49:53.872Z",
-      "created_by_ref": "identity--4ec4d0a2-80e3-41e6-ae22-56b6b6499611",
-      "id": "identity--1621d4d4-b67d-11e3-9670-f01faf20d111",
-      "identity_class": "unknown",
-      "modified": "2017-01-27T13:49:53.872Z",
-      "name": "Adversary Bravo",
-      "type": "identity"
-    },
-    {
-      "created": "2017-01-27T13:49:53.872Z",
-      "created_by_ref": "identity--4ec4d0a2-80e3-11e6-ae22-56b6b6499611",
-      "id": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f",
-      "labels": [
-        "unknown"
-      ],
-      "modified": "2017-01-27T13:49:53.872Z",
-      "name": "Adversary Bravo",
-      "sophistication": "unknown",
-      "type": "threat-actor"
-    },
-    {
-      "created": "2017-01-27T13:49:53.872Z",
-      "created_by_ref": "identity--4ec4d0a2-80e3-11e6-ae22-56b6b6499611",
-      "description": "Phishing",
-      "external_references": [
+    "id": "bundle--161f8ade-b67d-11e3-b8af-f01faf20d111",
+    "objects": [
         {
-          "external_id": "CAPEC-98",
-          "source_name": "capec"
+            "created": "2019-10-04T13:10:53.526Z",
+            "id": "identity--4ec4d0a2-80e3-11e6-ae22-56b6b6499611",
+            "identity_class": "unknown",
+            "modified": "2019-10-04T13:10:53.526Z",
+            "name": "Emmanuelle",
+            "type": "identity"
+        },
+        {
+            "created": "2019-10-04T13:10:53.526Z",
+            "created_by_ref": "identity--4ec4d0a2-80e3-41e6-ae22-56b6b6499611",
+            "id": "identity--1621d4d4-b67d-11e3-9670-f01faf20d111",
+            "identity_class": "unknown",
+            "modified": "2019-10-04T13:10:53.526Z",
+            "name": "Adversary Bravo",
+            "type": "identity"
+        },
+        {
+            "created": "2019-10-04T13:10:53.526Z",
+            "created_by_ref": "identity--4ec4d0a2-80e3-11e6-ae22-56b6b6499611",
+            "id": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f",
+            "labels": [
+                "unknown"
+            ],
+            "modified": "2019-10-04T13:10:53.526Z",
+            "name": "Adversary Bravo",
+            "sophistication": "unknown",
+            "type": "threat-actor"
+        },
+        {
+            "created": "2019-10-04T13:10:53.526Z",
+            "created_by_ref": "identity--4ec4d0a2-80e3-11e6-ae22-56b6b6499611",
+            "description": "Phishing",
+            "external_references": [
+                {
+                    "external_id": "CAPEC-98",
+                    "source_name": "capec"
+                }
+            ],
+            "id": "attack-pattern--8ac90ff3-ecf8-4835-95b8-6aea6a623df5",
+            "modified": "2019-10-04T13:10:53.526Z",
+            "name": "Phishing",
+            "type": "attack-pattern"
+        },
+        {
+            "created": "2019-10-04T13:10:53.526Z",
+            "id": "malware--1621d4d2-b67d-11e3-ba9e-f01faf20d111",
+            "labels": [
+                "remote-access-trojan"
+            ],
+            "modified": "2019-10-04T13:10:53.526Z",
+            "name": "Poison Ivy Variant d1c6",
+            "type": "malware",
+            "x_elevator_title": "Poison Ivy Variant d1c6"
+        },
+        {
+            "created": "2019-10-04T13:10:53.526Z",
+            "created_by_ref": "identity--4ec4d0a2-80e3-11e6-ae22-56b6b6499611",
+            "id": "relationship--1621d4d4-b67d-11e3-9670-f01faf20d111",
+            "modified": "2019-10-04T13:10:53.526Z",
+            "relationship_type": "attributed-to",
+            "source_ref": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f",
+            "target_ref": "identity--1621d4d4-b67d-11e3-9670-f01faf20d111",
+            "type": "relationship"
+        },
+        {
+            "created": "2019-10-04T13:10:53.526Z",
+            "created_by_ref": "identity--4ec4d0a2-80e3-11e6-ae22-56b6b6499611",
+            "description": "Leverages Attack Pattern",
+            "id": "relationship--cc5cc87e-82e6-4080-ac74-dbc8be6ac7aa",
+            "modified": "2019-10-04T13:10:53.526Z",
+            "relationship_type": "uses",
+            "source_ref": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f",
+            "target_ref": "attack-pattern--8ac90ff3-ecf8-4835-95b8-6aea6a623df5",
+            "type": "relationship"
+        },
+        {
+            "created": "2019-10-04T13:10:53.526Z",
+            "created_by_ref": "identity--4ec4d0a2-80e3-11e6-ae22-56b6b6499611",
+            "description": "Leverages Malware",
+            "id": "relationship--bfa57adf-f86a-420a-9420-9b55c761c348",
+            "modified": "2019-10-04T13:10:53.526Z",
+            "relationship_type": "uses",
+            "source_ref": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f",
+            "target_ref": "malware--1621d4d2-b67d-11e3-ba9e-f01faf20d111",
+            "type": "relationship"
         }
-      ],
-      "id": "attack-pattern--8ac90ff3-ecf8-4835-95b8-6aea6a623df5",
-      "modified": "2017-01-27T13:49:53.872Z",
-      "name": "Phishing",
-      "type": "attack-pattern"
-    },
-    {
-      "created": "2017-01-27T13:49:53.872Z",
-      "description": "\n\nTITLE:\n\tPoison Ivy Variant d1c6",
-      "id": "malware--1621d4d2-b67d-11e3-ba9e-f01faf20d111",
-      "labels": [
-        "remote-access-trojan"
-      ],
-      "modified": "2017-01-27T13:49:53.872Z",
-      "name": "Poison Ivy Variant d1c6",
-      "type": "malware"
-    },
-    {
-      "created": "2017-01-27T13:49:53.872Z",
-      "created_by_ref": "identity--4ec4d0a2-80e3-11e6-ae22-56b6b6499611",
-      "id": "relationship--1621d4d4-b67d-11e3-9670-f01faf20d111",
-      "modified": "2017-01-27T13:49:53.872Z",
-      "relationship_type": "attributed-to",
-      "source_ref": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f",
-      "target_ref": "identity--1621d4d4-b67d-11e3-9670-f01faf20d111",
-      "type": "relationship"
-    },
-    {
-      "created": "2017-01-27T13:49:53.872Z",
-      "created_by_ref": "identity--4ec4d0a2-80e3-11e6-ae22-56b6b6499611",
-      "description": "Leverages Attack Pattern",
-      "id": "relationship--e20d22c1-9141-4c1a-9804-dd79cb0f2069",
-      "modified": "2017-01-27T13:49:53.872Z",
-      "relationship_type": "uses",
-      "source_ref": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f",
-      "target_ref": "attack-pattern--8ac90ff3-ecf8-4835-95b8-6aea6a623df5",
-      "type": "relationship"
-    },
-    {
-      "created": "2017-01-27T13:49:53.872Z",
-      "created_by_ref": "identity--4ec4d0a2-80e3-11e6-ae22-56b6b6499611",
-      "description": "Leverages Malware",
-      "id": "relationship--bb9df45d-ec36-493f-ba29-ad5563818cd3",
-      "modified": "2017-01-27T13:49:53.872Z",
-      "relationship_type": "uses",
-      "source_ref": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f",
-      "target_ref": "malware--1621d4d2-b67d-11e3-ba9e-f01faf20d111",
-      "type": "relationship"
-    }
-  ],
-  "spec_version": "2.0",
-  "type": "bundle"
+    ],
+    "spec_version": "2.0",
+    "type": "bundle"
 }

--- a/idioms-json-2.0-valid/incident-malware.json
+++ b/idioms-json-2.0-valid/incident-malware.json
@@ -1,18 +1,56 @@
 {
-  "id": "bundle--65184e82-b693-11e3-bfd7-0800271e87d2",
-  "objects": [
-    {
-      "created": "2017-01-27T13:49:53.888Z",
-      "description": "\n\nTITLE:\n\tPoison Ivy",
-      "id": "malware--6516102d-b693-11e3-bfd7-0800271e87d2",
-      "labels": [
-        "remote-access-trojan"
-      ],
-      "modified": "2017-01-27T13:49:53.888Z",
-      "name": "Poison Ivy",
-      "type": "malware"
-    }
-  ],
-  "spec_version": "2.0",
-  "type": "bundle"
+    "id": "bundle--65184e82-b693-41e3-bfd7-0800271e87d2",
+    "objects": [
+        {
+            "created": "2014-05-08T09:00:00.000Z",
+            "id": "identity--6aedbecd-7323-4308-9cac-8fc71b9e10d2",
+            "identity_class": "unknown",
+            "modified": "2014-05-08T09:00:00.000Z",
+            "name": "Fred",
+            "type": "identity"
+        },
+        {
+            "created": "2014-05-08T09:00:00.000Z",
+            "id": "identity--f854887d-9e74-4e95-a2a0-f79af678768e",
+            "identity_class": "unknown",
+            "modified": "2014-05-08T09:00:00.000Z",
+            "name": "Barney",
+            "type": "identity"
+        },
+        {
+            "created": "2014-05-08T09:00:00.000Z",
+            "id": "x-elevator-incident--1b75ee8f-44d6-819a-d729-09ab52c91fdb",
+            "modified": "2014-05-08T09:00:00.000Z",
+            "name": "Detected Poison Ivy beaconing through perimeter firewalls",
+            "type": "x-elevator-incident",
+            "contacts": [
+                "identity--6aedbecd-7323-4308-9cac-8fc71b9e10d2",
+                "identity--f854887d-9e74-4e95-a2a0-f79af678768e"
+            ],
+            "status": "New"
+        },
+        {
+            "created": "2014-05-08T09:00:00.000Z",
+            "id": "malware--6516102d-b693-41e3-bfd7-0800271e87d2",
+            "labels": [
+                "remote-access-trojan"
+            ],
+            "modified": "2014-05-08T09:00:00.000Z",
+            "name": "Poison Ivy",
+            "type": "malware",
+            "x_elevator_title": "Poison Ivy"
+        },
+        {
+            "created": "2014-05-08T09:00:00.000Z",
+            "description": "Uses Malware",
+            "id": "relationship--dfc77494-4990-4d86-a4fc-0a20963fe6e2",
+            "modified": "2014-05-08T09:00:00.000Z",
+            "relationship_type": "related-to",
+            "source_ref": "x-elevator-incident--1b75ee8f-44d6-819a-d729-09ab52c91fdb",
+            "target_ref": "malware--6516102d-b693-41e3-bfd7-0800271e87d2",
+            "type": "relationship"
+        }
+    ],
+    "spec_version": "2.0",
+    "type": "bundle"
 }

--- a/idioms-json-2.0-valid/issue62.json
+++ b/idioms-json-2.0-valid/issue62.json
@@ -1,101 +1,106 @@
 {
-  "id": "bundle--6116aed6-a7e9-11e3-a82f-000c29b241af",
-  "objects": [
-    {
-      "created": "2018-07-30T13:03:43.987Z",
-      "id": "indicator--6116b44e-a7e9-11e3-a82f-000c29b241af",
-      "labels": [
-        "unknown"
-      ],
-      "modified": "2018-07-30T13:03:43.987Z",
-      "pattern": "[((file:hashes.MD5 = '5d8129be965fab8115eca34fc84bd7f0' OR file:hashes.'SHA-1' = '2b999e7db890cc77f0098a091de756a1803a3c2b' OR file:hashes.'SHA-256' = '2c5dd8a64437cb2dd4b6747139c61d2d7f53ab3ddedbf22df3cb01bae170715b' OR file:hashes.ssdeep = '768:mvAFYk0IOqi7RKW1RD1ZCrm82+AnbaAOdoOKL70ehP:cDIOqctz2rBmbZoa71hP') AND file:name = 'VirusShare_5d8129be965fab8115eca34fc84bd7f0' AND file:size = 40654 AND (((file:extensions.'windows-pebinary-ext'.sections[*].name = '.rdata' AND file:extensions.'windows-pebinary-ext'.sections[*].entropy = 7.74202363178) AND (file:extensions.'windows-pebinary-ext'.sections[*].name = '.data' AND file:extensions.'windows-pebinary-ext'.sections[*].entropy = 7.89204688601) AND (file:extensions.'windows-pebinary-ext'.sections[*].name = '.upx' AND file:extensions.'windows-pebinary-ext'.sections[*].entropy = 7.31815613066))))]",
-      "type": "indicator",
-      "valid_from": "2018-07-30T13:03:43.987655Z"
-    },
-    {
-      "created": "2018-07-30T13:03:43.991Z",
-      "id": "indicator--6116cf88-a7e9-11e3-a82f-000c29b241af",
-      "labels": [
-        "unknown"
-      ],
-      "modified": "2018-07-30T13:03:43.991Z",
-      "pattern": "[((file:hashes.MD5 = 'd41d8cd98f00b204e9800998ecf8427e' OR file:hashes.'SHA-1' = 'da39a3ee5e6b4b0d3255bfef95601890afd80709' OR file:hashes.'SHA-256' = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855') AND file:name = 'autoexec.bat' AND file:size = 0)]",
-      "type": "indicator",
-      "valid_from": "2018-07-30T13:03:43.991158Z"
-    },
-    {
-      "created": "2018-07-30T13:03:43.992Z",
-      "id": "indicator--6116d730-a7e9-11e3-a82f-000c29b241af",
-      "labels": [
-        "unknown"
-      ],
-      "modified": "2018-08-21T09:30:27.969Z",
-      "pattern": "[(process:pid = 1700 AND process:parent_ref.pid = 1616 AND process:creator_user_ref.user_id = 'admin' AND process:created = t'2010-12-09T20:17:34.934295Z' AND process:command_line = 'bash some.sh') AND process:environment_variables[*].PROXY = '123.456.0.1' AND process:child_refs[*].pid = 4567 AND process:opened_connection_refs[*].dst_ref.value = '198.49.123.10' AND process:extensions.'windows-process-ext'.window_title = 'Some Title']",
-      "type": "indicator",
-      "valid_from": "2018-07-30T13:03:43.992158Z"
-    },
-    {
-      "created": "2018-07-30T13:03:43.992Z",
-      "id": "indicator--6116dcbc-a7e9-11e3-a82f-000c29b241af",
-      "labels": [
-        "unknown"
-      ],
-      "modified": "2018-07-30T13:03:43.992Z",
-      "pattern": "[(windows-registry-key:key = 'HKEY_CURRENT_USER\\\\Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Explorer\\\\User Shell Folders' AND windows-registry-key:key = 'HKEY_CURRENT_USER\\\\Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Explorer\\\\Shell Folders' AND windows-registry-key:key = 'HKEY_LOCAL_MACHINE\\\\Software\\\\Microsoft\\\\Tracing' AND windows-registry-key:key = 'HKEY_LOCAL_MACHINE\\\\Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Explorer\\\\User Shell Folders' AND windows-registry-key:key = 'Software\\\\Microsoft\\\\Windows NT\\\\CurrentVersion\\\\Winlogon' AND windows-registry-key:key = 'HKEY_LOCAL_MACHINE\\\\Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Explorer\\\\Shell Folders' AND windows-registry-key:key = 'Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Explorer\\\\User Shell Folders' AND windows-registry-key:key = 'Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Explorer\\\\Shell Folders' AND windows-registry-key:key = 'Software\\\\Microsoft\\\\windows\\\\CurrentVersion\\\\Internet Settings' AND windows-registry-key:key = 'Software\\\\Microsoft\\\\windows\\\\CurrentVersion\\\\Internet Settings\\\\Connections' AND windows-registry-key:key = 'HKEY_CURRENT_CONFIG\\\\Software\\\\Microsoft\\\\windows\\\\CurrentVersion\\\\Internet Settings' AND windows-registry-key:key = 'Software\\\\Microsoft\\\\SystemCertificates\\\\MY' AND windows-registry-key:key = 'HKEY_LOCAL_MACHINE\\\\System\\\\CurrentControlSet\\\\Services\\\\Tcpip\\\\Parameters')]",
-      "type": "indicator",
-      "valid_from": "2018-08-21T09:30:27.972376Z"
-    },
-    {
-      "created": "2018-08-21T09:30:27.964Z",
-      "first_observed": "2018-08-21T09:30:27.964Z",
-      "id": "observed-data--65492fbc-5d48-49bf-83b8-33c965e36066",
-      "last_observed": "2018-08-21T09:30:27.964Z",
-      "modified": "2018-08-21T09:30:27.964Z",
-      "number_observed": 1,
-      "objects": {
-        "0": {
-          "arguments": [
-            "--p",
-            "some_file.txt"
-          ],
-          "child_refs": [
-            "1"
-          ],
-          "created": "2010-12-09T20:17:34.934295Z",
-          "extensions": {
-            "windows-process-ext": {
-              "window_title": "Some Title"
-            }
-          },
-          "name": "VirusShare_5d8129be965fab8115eca34fc84bd7f0",
-          "opened_connection_refs": [
-            "4"
-          ],
-          "parent_ref": "2",
-          "pid": 1700,
-          "type": "process"
+    "id": "bundle--6116aed6-a7e9-41e3-a82f-000c29b241af",
+    "objects": [
+        {
+            "created": "2020-02-11T14:25:20.680Z",
+            "id": "indicator--6116b44e-a7e9-41e3-a82f-000c29b241af",
+            "labels": [
+                "unknown"
+            ],
+            "modified": "2020-02-11T14:25:20.680Z",
+            "pattern": "[(file:hashes.MD5 = '5d8129be965fab8115eca34fc84bd7f0' OR file:hashes.'SHA-1' = '2b999e7db890cc77f0098a091de756a1803a3c2b' OR file:hashes.'SHA-256' = '2c5dd8a64437cb2dd4b6747139c61d2d7f53ab3ddedbf22df3cb01bae170715b' OR file:hashes.ssdeep = '768:mvAFYk0IOqi7RKW1RD1ZCrm82+AnbaAOdoOKL70ehP:cDIOqctz2rBmbZoa71hP') AND file:name = 'VirusShare_5d8129be965fab8115eca34fc84bd7f0' AND file:size = 40654 AND (((file:extensions.'windows-pebinary-ext'.sections[*].name = '.rdata' AND file:extensions.'windows-pebinary-ext'.sections[*].x_elevator_entropy_min < 10.0 AND file:extensions.'windows-pebinary-ext'.sections[*].entropy = 7.74202363178) AND (file:extensions.'windows-pebinary-ext'.sections[*].name = '.data' AND file:extensions.'windows-pebinary-ext'.sections[*].entropy = 7.89204688601) AND (file:extensions.'windows-pebinary-ext'.sections[*].name = '.upx' AND file:extensions.'windows-pebinary-ext'.sections[*].entropy = 7.31815613066)) AND file:extensions.'windows-pebinary-ext'.x_elevator_imports[*] = 'GetProcAddress')]",
+            "type": "indicator",
+            "valid_from": "2020-02-11T14:25:20.680Z"
         },
-        "1": {
-          "pid": 4567,
-          "type": "process"
+        {
+            "created": "2020-02-11T14:25:20.680Z",
+            "id": "indicator--6116cf88-a7e9-41e3-a82f-000c29b241af",
+            "labels": [
+                "unknown"
+            ],
+            "modified": "2020-02-11T14:25:20.680Z",
+            "pattern": "[(file:hashes.MD5 = 'd41d8cd98f00b204e9800998ecf8427e' OR file:hashes.'SHA-1' = 'da39a3ee5e6b4b0d3255bfef95601890afd80709' OR file:hashes.'SHA-256' = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855') AND file:name = 'autoexec.bat' AND file:size = 0]",
+            "type": "indicator",
+            "valid_from": "2020-02-11T14:25:20.680Z"
         },
-        "2": {
-          "pid": 1616,
-          "type": "process"
+        {
+            "created": "2020-02-11T14:25:20.680Z",
+            "id": "indicator--6116d730-a7e9-41e3-a82f-000c29b241af",
+            "labels": [
+                "unknown"
+            ],
+            "modified": "2020-02-11T14:25:20.680Z",
+            "pattern": "[process:pid = 1700 AND process:name = 'VirusShare_5d8129be965fab8115eca34fc84bd7f0' AND process:parent_ref.pid = 1616 AND process:creator_user_ref.user_id = 'admin' AND process:created = t'2010-12-09T20:17:34.934295Z' AND process:command_line = 'bash some.sh' AND (process:arguments[*] = '--p' AND process:arguments[*] = 'some_file.txt') AND process:environment_variables[*].PROXY = '123.456.0.1' AND process:child_refs[*].pid = 4567 AND process:opened_connection_refs[*].dst_ref.value = '198.49.123.10' AND process:extensions.'windows-process-ext'.window_title = 'Some Title']",
+            "type": "indicator",
+            "valid_from": "2020-02-11T14:25:20.680Z"
         },
-        "3": {
-          "type": "ipv4-addr",
-          "value": "198.49.123.10"
+        {
+            "created": "2020-02-11T14:25:20.680Z",
+            "id": "indicator--6116dcbc-a7e9-41e3-a82f-000c29b241af",
+            "labels": [
+                "unknown"
+            ],
+            "modified": "2020-02-11T14:25:20.680Z",
+            "pattern": "[windows-registry-key:key = 'HKEY_CURRENT_USER\\\\Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Explorer\\\\User Shell Folders'] AND [windows-registry-key:key = 'HKEY_CURRENT_USER\\\\Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Explorer\\\\Shell Folders'] AND [windows-registry-key:key = 'HKEY_LOCAL_MACHINE\\\\Software\\\\Microsoft\\\\Tracing'] AND [windows-registry-key:key = 'HKEY_LOCAL_MACHINE\\\\Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Explorer\\\\User Shell Folders'] AND [windows-registry-key:key = 'Software\\\\Microsoft\\\\Windows NT\\\\CurrentVersion\\\\Winlogon'] AND [windows-registry-key:key = 'HKEY_LOCAL_MACHINE\\\\Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Explorer\\\\Shell Folders'] AND [windows-registry-key:key = 'Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Explorer\\\\User Shell Folders'] AND [windows-registry-key:key = 'Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Explorer\\\\Shell Folders'] AND [windows-registry-key:key = 'Software\\\\Microsoft\\\\windows\\\\CurrentVersion\\\\Internet Settings'] AND [windows-registry-key:key = 'Software\\\\Microsoft\\\\windows\\\\CurrentVersion\\\\Internet Settings\\\\Connections'] AND [windows-registry-key:key = 'HKEY_CURRENT_CONFIG\\\\Software\\\\Microsoft\\\\windows\\\\CurrentVersion\\\\Internet Settings'] AND [windows-registry-key:key = 'Software\\\\Microsoft\\\\SystemCertificates\\\\MY'] AND [windows-registry-key:key = 'HKEY_LOCAL_MACHINE\\\\System\\\\CurrentControlSet\\\\Services\\\\Tcpip\\\\Parameters']",
+            "type": "indicator",
+            "valid_from": "2020-02-11T14:25:20.680Z"
         },
-        "4": {
-          "dst_port": 80,
-          "dst_ref": "3",
-          "type": "network-traffic"
+        {
+            "created": "2020-02-11T14:25:20.680Z",
+            "first_observed": "2020-02-11T14:25:20.680Z",
+            "id": "observed-data--65492fbc-5d48-49bf-83b8-33c965e36066",
+            "last_observed": "2020-02-11T14:25:20.680Z",
+            "modified": "2020-02-11T14:25:20.680Z",
+            "number_observed": 1,
+            "objects": {
+                "0": {
+                    "arguments": [
+                        "--p",
+                        "some_file.txt"
+                    ],
+                    "child_refs": [
+                        "4"
+                    ],
+                    "created": "2010-12-09T20:17:34.934295Z",
+                    "creator_user_ref": "3",
+                    "extensions": {
+                        "windows-process-ext": {
+                            "window_title": "Some Title"
+                        }
+                    },
+                    "name": "VirusShare_5d8129be965fab8115eca34fc84bd7f0",
+                    "opened_connection_refs": [
+                        "1"
+                    ],
+                    "parent_ref": "5",
+                    "pid": 1700,
+                    "type": "process"
+                },
+                "1": {
+                    "dst_port": 80,
+                    "dst_ref": "1",
+                    "type": "network-traffic"
+                },
+                "2": {
+                    "type": "ipv4-addr",
+                    "value": "198.49.123.10"
+                },
+                "3": {
+                    "type": "user-account",
+                    "user_id": "admin"
+                },
+                "4": {
+                    "pid": 4567,
+                    "type": "process"
+                },
+                "5": {
+                    "pid": 1616,
+                    "type": "process"
+                }
+            },
+            "type": "observed-data"
         }
-      },
-      "type": "observed-data"
-    }
-  ],
-  "spec_version": "2.0",
-  "type": "bundle"
+    ],
+    "spec_version": "2.0",
+    "type": "bundle"
 }

--- a/idioms-json-2.0-valid/malicious-email-indicator-with-addresses.json
+++ b/idioms-json-2.0-valid/malicious-email-indicator-with-addresses.json
@@ -1,27 +1,60 @@
 {
-  "id": "bundle--8b8ed1c1-f01d-4393-ac65-97017ed15876",
-  "objects": [
-    {
-      "created": "2014-10-31T15:52:13.126Z",
-      "id": "indicator--b06b0eb7-61dd-4338-a094-0290c380fbd8",
-      "labels": [
-        "malicious-email"
-      ],
-      "modified": "2014-10-31T15:52:13.126Z",
-      "name": "Malicious E-mail Addresses",
-      "pattern": "[(email-message:from_ref.value = 'fred@abc.com' AND (email-message:to_refs[*].value = 'barney@abc.com' OR email-message:to_refs[*].value = 'wilma@abc.com'))]",
-      "type": "indicator",
-      "valid_from": "2014-10-31T15:52:13.126999Z"
-    },
-    {
-      "created": "2014-10-31T15:52:13.126Z",
-      "id": "relationship--67b8cf7b-f8b1-4df5-8903-ab9028b098f7",
-      "modified": "2014-10-31T15:52:13.126Z",
-      "relationship_type": "indicates",
-      "source_ref": "indicator--b06b0eb7-61dd-4338-a094-0290c380fbd8",
-      "type": "relationship"
-    }
-  ],
-  "spec_version": "2.0",
-  "type": "bundle"
+    "id": "bundle--8b8ed1c1-f01d-4393-ac65-97017ed15876",
+    "objects": [
+        {
+            "created": "2014-10-31T15:52:13.126Z",
+            "id": "indicator--b06b0eb7-61dd-4338-a094-0290c380fbd8",
+            "labels": [
+                "malicious-email"
+            ],
+            "modified": "2014-10-31T15:52:13.126Z",
+            "name": "Malicious E-mail Addresses",
+            "pattern": "[email-message:from_ref.value IN ('fred@abc.com', 'betty@abc.com') AND (email-message:to_refs[*].value = 'barney@abc.com' OR email-message:to_refs[*].value = 'wilma@abc.com') AND email-message:message_id = '20131031123417.u1BKfrXh004925@mail-gw-01.abc.com']",
+            "type": "indicator",
+            "valid_from": "2014-10-31T15:52:13.126999Z",
+            "x_elevator_confidence": "Low"
+        },
+        {
+            "created": "2014-10-31T15:52:13.126Z",
+            "id": "relationship--acbdcc6e-1ba3-47de-97d9-3a160ca9fdaa",
+            "modified": "2014-10-31T15:52:13.126Z",
+            "relationship_type": "indicates",
+            "source_ref": "indicator--b06b0eb7-61dd-4338-a094-0290c380fbd8",
+            "type": "relationship"
+        },
+        {
+            "created": "2020-06-03T13:04:06.068Z",
+            "first_observed": "2020-06-03T13:04:06.068Z",
+            "id": "observed-data--da84c823-199b-4e76-a4b9-f8565b952979",
+            "last_observed": "2020-06-03T13:04:06.068Z",
+            "modified": "2020-06-03T13:04:06.068Z",
+            "number_observed": 1,
+            "objects": {
+                "0": {
+                    "from_ref": "1",
+                    "is_multipart": false,
+                    "to_refs": [
+                        "2",
+                        "3"
+                    ],
+                    "type": "email-message"
+                },
+                "1": {
+                    "type": "email-addr",
+                    "value": "fred@abc.com"
+                },
+                "2": {
+                    "type": "email-addr",
+                    "value": "barney@abc.com"
+                },
+                "3": {
+                    "type": "email-addr",
+                    "value": "wilma@abc.com"
+                }
+            },
+            "type": "observed-data"
+        }
+    ],
+    "spec_version": "2.0",
+    "type": "bundle"
 }

--- a/idioms-json-2.0-valid/malicious-email-indicator-with-attachment.json
+++ b/idioms-json-2.0-valid/malicious-email-indicator-with-attachment.json
@@ -1,93 +1,96 @@
 {
-  "id": "bundle--8b8ed1c1-f01d-4393-ac65-97017ed15876",
-  "objects": [
-    {
-      "created": "2014-10-31T15:52:13.127Z",
-      "id": "indicator--8cf9236f-1b96-493d-98be-0c1c1e8b62d7",
-      "labels": [
-        "malicious-email"
-      ],
-      "modified": "2014-10-31T15:52:13.127Z",
-      "name": "Malicious E-mail",
-      "pattern": "[(email-message:subject MATCHES '^[IMPORTANT] Please Review Before' AND email-message:body_multipart[*].body_raw_ref.name MATCHES '^Final Report*.doc.exe$')]",
-      "type": "indicator",
-      "valid_from": "2014-10-31T15:52:13.127931Z"
-    },
-    {
-      "created": "2014-10-31T15:52:13.126Z",
-      "id": "indicator--b06b0eb7-61dd-4338-a094-0290c380fbd8",
-      "labels": [
-        "malicious-email"
-      ],
-      "modified": "2014-10-31T15:52:13.126Z",
-      "name": "Malicious E-mail Subject Line",
-      "pattern": "[email-message:subject MATCHES '^[IMPORTANT] Please Review Before']",
-      "type": "indicator",
-      "valid_from": "2014-10-31T15:52:13.126999Z"
-    },
-    {
-      "created": "2014-10-31T15:52:13.127Z",
-      "id": "indicator--2e17f6fe-3a4d-438a-911a-e509ba1b9933",
-      "labels": [
-        "malicious-email"
-      ],
-      "modified": "2014-10-31T15:52:13.127Z",
-      "name": "Malicious E-mail Attachment",
-      "pattern": "[file:name MATCHES '^Final Report*.doc.exe$'] AND [email-message:body_multipart[*].body_raw_ref.name MATCHES '^Final Report*.doc.exe$']",
-      "type": "indicator",
-      "valid_from": "2014-10-31T15:52:13.127668Z"
-    },
-    {
-      "created": "2014-10-31T15:52:13.127Z",
-      "id": "relationship--f50e63f5-fc39-481a-95e0-40eced3ae8f4",
-      "modified": "2014-10-31T15:52:13.127Z",
-      "relationship_type": "indicates",
-      "source_ref": "indicator--8cf9236f-1b96-493d-98be-0c1c1e8b62d7",
-      "type": "relationship"
-    },
-    {
-      "created": "2014-10-31T15:52:13.126Z",
-      "id": "relationship--769b61c6-859d-4461-ac37-9079c3cce0ab",
-      "modified": "2014-10-31T15:52:13.126Z",
-      "relationship_type": "indicates",
-      "source_ref": "indicator--b06b0eb7-61dd-4338-a094-0290c380fbd8",
-      "type": "relationship"
-    },
-    {
-      "created": "2014-10-31T15:52:13.127Z",
-      "id": "relationship--738a6f2f-ed06-4bfd-a1f6-0741caa41f8d",
-      "modified": "2014-10-31T15:52:13.127Z",
-      "relationship_type": "indicates",
-      "source_ref": "indicator--2e17f6fe-3a4d-438a-911a-e509ba1b9933",
-      "type": "relationship"
-    },
-    {
-      "created": "2018-08-18T14:14:42.346Z",
-      "first_observed": "2018-08-18T14:14:42.346Z",
-      "id": "observed-data--2305f359-ab46-4932-acaf-953c31cd8b22",
-      "last_observed": "2018-08-18T14:14:42.346Z",
-      "modified": "2018-08-18T14:14:42.346Z",
-      "number_observed": 1,
-      "objects": {
-        "0": {
-          "body_multipart": [
-            {
-              "body_raw_ref": "1",
-              "content_type": "text/plain"
-            }
-          ],
-          "is_multipart": true,
-          "subject": "[IMPORTANT] Please Review Before",
-          "type": "email-message"
+    "id": "bundle--8b8ed1c1-f01d-4393-ac65-97017ed15876",
+    "objects": [
+        {
+            "created": "2014-10-31T15:52:13.127Z",
+            "id": "indicator--8cf9236f-1b96-493d-98be-0c1c1e8b62d7",
+            "labels": [
+                "malicious-email"
+            ],
+            "modified": "2014-10-31T15:52:13.127Z",
+            "name": "Malicious E-mail",
+            "pattern": "[email-message:subject MATCHES '^[IMPORTANT] Please Review Before' AND email-message:body_multipart[*].body_raw_ref.name MATCHES '^Final Report*.doc.exe$']",
+            "type": "indicator",
+            "valid_from": "2014-10-31T15:52:13.127931Z",
+            "x_elevator_confidence": "High"
         },
-        "1": {
-          "name": "Final Report",
-          "type": "file"
+        {
+            "created": "2014-10-31T15:52:13.126Z",
+            "id": "indicator--b06b0eb7-61dd-4338-a094-0290c380fbd8",
+            "labels": [
+                "malicious-email"
+            ],
+            "modified": "2014-10-31T15:52:13.126Z",
+            "name": "Malicious E-mail Subject Line",
+            "pattern": "[email-message:subject MATCHES '^[IMPORTANT] Please Review Before']",
+            "type": "indicator",
+            "valid_from": "2014-10-31T15:52:13.126999Z",
+            "x_elevator_confidence": "Low"
+        },
+        {
+            "created": "2014-10-31T15:52:13.127Z",
+            "id": "indicator--2e17f6fe-3a4d-438a-911a-e509ba1b9933",
+            "labels": [
+                "malicious-email"
+            ],
+            "modified": "2014-10-31T15:52:13.127Z",
+            "name": "Malicious E-mail Attachment",
+            "pattern": "[file:name MATCHES '^Final Report*.doc.exe$'] AND [email-message:body_multipart[*].body_raw_ref.name MATCHES '^Final Report*.doc.exe$']",
+            "type": "indicator",
+            "valid_from": "2014-10-31T15:52:13.127668Z",
+            "x_elevator_confidence": "Low"
+        },
+        {
+            "created": "2014-10-31T15:52:13.127Z",
+            "id": "relationship--e341a4f1-f210-4360-b923-a502a63348ce",
+            "modified": "2014-10-31T15:52:13.127Z",
+            "relationship_type": "indicates",
+            "source_ref": "indicator--8cf9236f-1b96-493d-98be-0c1c1e8b62d7",
+            "type": "relationship"
+        },
+        {
+            "created": "2014-10-31T15:52:13.126Z",
+            "id": "relationship--cc2bab61-68f0-43ed-82e4-d2f6db1273c9",
+            "modified": "2014-10-31T15:52:13.126Z",
+            "relationship_type": "indicates",
+            "source_ref": "indicator--b06b0eb7-61dd-4338-a094-0290c380fbd8",
+            "type": "relationship"
+        },
+        {
+            "created": "2014-10-31T15:52:13.127Z",
+            "id": "relationship--487e1967-cded-4a91-a46f-9974eabf6bad",
+            "modified": "2014-10-31T15:52:13.127Z",
+            "relationship_type": "indicates",
+            "source_ref": "indicator--2e17f6fe-3a4d-438a-911a-e509ba1b9933",
+            "type": "relationship"
+        },
+        {
+            "created": "2019-10-04T13:10:53.843Z",
+            "first_observed": "2019-10-04T13:10:53.843Z",
+            "id": "observed-data--2305f359-ab46-4932-acaf-953c31cd8b22",
+            "last_observed": "2019-10-04T13:10:53.843Z",
+            "modified": "2019-10-04T13:10:53.843Z",
+            "number_observed": 1,
+            "objects": {
+                "0": {
+                    "body_multipart": [
+                        {
+                            "body_raw_ref": "1",
+                            "content_type": "text/plain"
+                        }
+                    ],
+                    "is_multipart": true,
+                    "subject": "[IMPORTANT] Please Review Before",
+                    "type": "email-message"
+                },
+                "1": {
+                    "name": "Final Report.doc.exe",
+                    "type": "file"
+                }
+            },
+            "type": "observed-data"
         }
-      },
-      "type": "observed-data"
-    }
-  ],
-  "spec_version": "2.0",
-  "type": "bundle"
+    ],
+    "spec_version": "2.0",
+    "type": "bundle"
 }

--- a/idioms-json-2.0-valid/network-socket-observable.json
+++ b/idioms-json-2.0-valid/network-socket-observable.json
@@ -15,12 +15,13 @@
               "address_family": "AF_INET",
               "is_listening": true,
               "options": {
-                "IP_MULTICAST_LOOP": true
-              }
+                "IP_MULTICAST_LOOP": 1
+              },
+              "x_elevator_local_address": "198.51.100.2"
             }
           },
           "protocols": [
-            "TCP"
+            "tcp"
           ],
           "type": "network-traffic"
         }

--- a/idioms-json-2.0-valid/threat-actor-leveraging-attack-patterns-and-malware.json
+++ b/idioms-json-2.0-valid/threat-actor-leveraging-attack-patterns-and-malware.json
@@ -1,79 +1,80 @@
 {
-  "id": "bundle--161f8ade-b67d-11e3-b8af-f01faf20d111",
-  "objects": [
-    {
-      "created": "2017-01-27T13:49:54.326Z",
-      "id": "identity--1621d4d4-b67d-11e3-9670-f01faf20d111",
-      "modified": "2017-01-27T13:49:54.326Z",
-      "name": "Adversary Bravo",
-      "type": "identity"
-    },
-    {
-      "created": "2017-01-27T13:49:54.326Z",
-      "id": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f",
-      "labels": [
-        "unknown"
-      ],
-      "modified": "2017-01-27T13:49:54.326Z",
-      "name": "Adversary Bravo",
-      "sophistication": "unknown",
-      "type": "threat-actor"
-    },
-    {
-      "created": "2017-01-27T13:49:54.326Z",
-      "description": "Phishing",
-      "external_references": [
+    "id": "bundle--161f8ade-b67d-11e3-b8af-f01faf20d111",
+    "objects": [
         {
-          "external_id": "CAPEC-98",
-          "source_name": "capec"
+            "created": "2019-10-04T13:10:54.256Z",
+            "id": "identity--1621d4d4-b67d-11e3-9670-f01faf20d111",
+            "identity_class": "unknown",
+            "modified": "2019-10-04T13:10:54.256Z",
+            "name": "Adversary Bravo",
+            "type": "identity"
+        },
+        {
+            "created": "2019-10-04T13:10:54.256Z",
+            "id": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f",
+            "labels": [
+                "unknown"
+            ],
+            "modified": "2019-10-04T13:10:54.256Z",
+            "name": "Adversary Bravo",
+            "sophistication": "unknown",
+            "type": "threat-actor"
+        },
+        {
+            "created": "2019-10-04T13:10:54.256Z",
+            "description": "Phishing",
+            "external_references": [
+                {
+                    "external_id": "CAPEC-98",
+                    "source_name": "capec"
+                }
+            ],
+            "id": "attack-pattern--8ac90ff3-ecf8-4835-95b8-6aea6a623df5",
+            "modified": "2019-10-04T13:10:54.256Z",
+            "name": "Phishing",
+            "type": "attack-pattern"
+        },
+        {
+            "created": "2019-10-04T13:10:54.256Z",
+            "id": "malware--1621d4d2-b67d-11e3-ba9e-f01faf20d111",
+            "labels": [
+                "remote-access-trojan"
+            ],
+            "modified": "2019-10-04T13:10:54.256Z",
+            "name": "Poison Ivy Variant d1c6",
+            "type": "malware",
+            "x_elevator_title": "Poison Ivy Variant d1c6"
+        },
+        {
+            "created": "2019-10-04T13:10:54.256Z",
+            "id": "relationship--1621d4d4-b67d-11e3-9670-f01faf20d111",
+            "modified": "2019-10-04T13:10:54.256Z",
+            "relationship_type": "attributed-to",
+            "source_ref": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f",
+            "target_ref": "identity--1621d4d4-b67d-11e3-9670-f01faf20d111",
+            "type": "relationship"
+        },
+        {
+            "created": "2019-10-04T13:10:54.256Z",
+            "description": "Leverages Attack Pattern",
+            "id": "relationship--45e5b810-1cc0-4dd0-84ef-812eeab5f4da",
+            "modified": "2019-10-04T13:10:54.256Z",
+            "relationship_type": "uses",
+            "source_ref": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f",
+            "target_ref": "attack-pattern--8ac90ff3-ecf8-4835-95b8-6aea6a623df5",
+            "type": "relationship"
+        },
+        {
+            "created": "2019-10-04T13:10:54.256Z",
+            "description": "Leverages Malware",
+            "id": "relationship--56de4b8c-c304-4b28-8e54-c5f268ddf476",
+            "modified": "2019-10-04T13:10:54.256Z",
+            "relationship_type": "uses",
+            "source_ref": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f",
+            "target_ref": "malware--1621d4d2-b67d-11e3-ba9e-f01faf20d111",
+            "type": "relationship"
         }
-      ],
-      "id": "attack-pattern--8ac90ff3-ecf8-4835-95b8-6aea6a623df5",
-      "modified": "2017-01-27T13:49:54.326Z",
-      "name": "Phishing",
-      "type": "attack-pattern"
-    },
-    {
-      "created": "2017-01-27T13:49:54.326Z",
-      "description": "\n\nTITLE:\n\tPoison Ivy Variant d1c6",
-      "id": "malware--1621d4d2-b67d-11e3-ba9e-f01faf20d111",
-      "labels": [
-        "remote-access-trojan"
-      ],
-      "modified": "2017-01-27T13:49:54.326Z",
-      "name": "Poison Ivy Variant d1c6",
-      "type": "malware"
-    },
-    {
-      "created": "2017-01-27T13:49:54.326Z",
-      "id": "relationship--1621d4d4-b67d-11e3-9670-f01faf20d111",
-      "modified": "2017-01-27T13:49:54.326Z",
-      "relationship_type": "attributed-to",
-      "source_ref": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f",
-      "target_ref": "identity--1621d4d4-b67d-11e3-9670-f01faf20d111",
-      "type": "relationship"
-    },
-    {
-      "created": "2017-01-27T13:49:54.326Z",
-      "description": "Leverages Attack Pattern",
-      "id": "relationship--f287f87c-4179-45e7-96d3-db2784dc1976",
-      "modified": "2017-01-27T13:49:54.326Z",
-      "relationship_type": "uses",
-      "source_ref": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f",
-      "target_ref": "attack-pattern--8ac90ff3-ecf8-4835-95b8-6aea6a623df5",
-      "type": "relationship"
-    },
-    {
-      "created": "2017-01-27T13:49:54.326Z",
-      "description": "Leverages Malware",
-      "id": "relationship--d3c589e2-4db8-437f-afdb-da12929cdefa",
-      "modified": "2017-01-27T13:49:54.326Z",
-      "relationship_type": "uses",
-      "source_ref": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f",
-      "target_ref": "malware--1621d4d2-b67d-11e3-ba9e-f01faf20d111",
-      "type": "relationship"
-    }
-  ],
-  "spec_version": "2.0",
-  "type": "bundle"
+    ],
+    "spec_version": "2.0",
+    "type": "bundle"
 }

--- a/idioms-json-2.0-valid/ttp-names-title-1.json
+++ b/idioms-json-2.0-valid/ttp-names-title-1.json
@@ -1,0 +1,19 @@
+{
+    "id": "bundle--22b3dcfc-1d87-4b35-ba61-7d7c14f28557",
+    "objects": [
+        {
+            "created": "2015-05-15T09:00:00.000Z",
+            "description": "Poison Ivy is a remote access tool that is freely available for download from its official web site at www.poisonivy-rat.com. First released in 2005, the tool has gone unchanged since 2008 with version 2.3.2. Poison Ivy includes features common to most Windows-based RATs, including key logging, screen capturing, video capturing, file transfers, system administration, password theft, and traffic relaying.\n\nPoison Ivy's wide availability and easy-to-use features make it a popular choice for all kinds of criminals. But it is probably most notable for its role in many high profile, targeted APT attacks.\n\nThese APTs pursue specific targets, using RATs to maintain a persistent presence within the target's network. They move laterally and escalate system privileges to extract sensitive information-whenever the attacker wants to do so.4,5 Because some RATs used in targeted attacks are widely available, determining whether an attack is part of a broader APT campaign can be difficult. Equally challenging is identifying malicious traffic to determine the attacker's post-compromise activities and assess overall damage-these RATs often encrypt their network communications after the initial exploit.\n\nIn 2011, three years after the most recent release of PIVY, attackers used the RAT to compromise security firm RSA and steal data about its SecureID authentication system. That data was subsequently used in other attacks. The RSA attack was linked to Chinese threat actors and described at the time as extremely sophisticated. Exploiting a zero-day vulnerability, the attack delivered PIVY as the payload. It was not an isolated incident. The campaign appears to have started in 2010, with many other companies compromised.\n\nPIVY also played a key role in the 2011 campaign known as Nitro that targeted chemical makers, government agencies, defense contractors, and human rights groups. Still active a year later, the Nitro attackers used a zero-day vulnerability in Java to deploy PIVY in 2012. Just recently, PIVY was the payload of a zero-day exploit in Internet Explorer used in what is known as a \"strategic web compromise\" attack against visitors to a U.S. government website and a variety of others.\n\nRATs require live, direct, real-time human interaction by the APT attacker. This characteristic is distinctly different from crimeware (malware focused on cybercrime), where the criminal can issue commands to their botnet of compromised endpoints whenever they please and set them to work on a common goal such as a spam relay. In contrast, RATs are much more personal and may indicate that you are dealing with a dedicated threat actor that is interested in your organization specifically.\n",
+            "id": "malware--82f13157-93a5-4486-ad00-c0397059d8ac",
+            "labels": [
+                "unknown"
+            ],
+            "modified": "2015-05-15T09:00:00.000Z",
+            "name": "Poison Ivy (PIVY)",
+            "type": "malware",
+            "x_elevator_title": "Poison Ivy (PIVY) Title"
+        }
+    ],
+    "spec_version": "2.0",
+    "type": "bundle"
+}

--- a/idioms-json-2.0-valid/ttp-names-title-4.json
+++ b/idioms-json-2.0-valid/ttp-names-title-4.json
@@ -1,0 +1,22 @@
+{
+    "id": "bundle--6f8bfbf8-2e54-4321-9316-2ce80f33322d",
+    "objects": [
+        {
+            "created": "2015-05-15T09:00:00.000Z",
+            "description": "Poison Ivy is a remote access tool that is freely available for download from its official web site at www.poisonivy-rat.com. First released in 2005, the tool has gone unchanged since 2008 with version 2.3.2. Poison Ivy includes features common to most Windows-based RATs, including key logging, screen capturing, video capturing, file transfers, system administration, password theft, and traffic relaying.\n\nPoison Ivy's wide availability and easy-to-use features make it a popular choice for all kinds of criminals. But it is probably most notable for its role in many high profile, targeted APT attacks.\n\nThese APTs pursue specific targets, using RATs to maintain a persistent presence within the target's network. They move laterally and escalate system privileges to extract sensitive information-whenever the attacker wants to do so.4,5 Because some RATs used in targeted attacks are widely available, determining whether an attack is part of a broader APT campaign can be difficult. Equally challenging is identifying malicious traffic to determine the attacker's post-compromise activities and assess overall damage-these RATs often encrypt their network communications after the initial exploit.\n\nIn 2011, three years after the most recent release of PIVY, attackers used the RAT to compromise security firm RSA and steal data about its SecureID authentication system. That data was subsequently used in other attacks. The RSA attack was linked to Chinese threat actors and described at the time as extremely sophisticated. Exploiting a zero-day vulnerability, the attack delivered PIVY as the payload. It was not an isolated incident. The campaign appears to have started in 2010, with many other companies compromised.\n\nPIVY also played a key role in the 2011 campaign known as Nitro that targeted chemical makers, government agencies, defense contractors, and human rights groups. Still active a year later, the Nitro attackers used a zero-day vulnerability in Java to deploy PIVY in 2012. Just recently, PIVY was the payload of a zero-day exploit in Internet Explorer used in what is known as a \"strategic web compromise\" attack against visitors to a U.S. government website and a variety of others.\n\nRATs require live, direct, real-time human interaction by the APT attacker. This characteristic is distinctly different from crimeware (malware focused on cybercrime), where the criminal can issue commands to their botnet of compromised endpoints whenever they please and set them to work on a common goal such as a spam relay. In contrast, RATs are much more personal and may indicate that you are dealing with a dedicated threat actor that is interested in your organization specifically.\n",
+            "id": "malware--497d1999-1dad-4977-9158-e25bb6b4fc42",
+            "labels": [
+                "unknown"
+            ],
+            "modified": "2015-05-15T09:00:00.000Z",
+            "name": "Poison Ivy (PIVY) 1",
+            "type": "malware",
+            "x_elevator_other_names": [
+                "Poison Ivy (PIVY) 2",
+                "Poison Ivy (PIVY) 3"
+            ]
+        }
+    ],
+    "spec_version": "2.0",
+    "type": "bundle"
+}

--- a/idioms-json-2.0-valid/victim-targeting.json
+++ b/idioms-json-2.0-valid/victim-targeting.json
@@ -1,23 +1,36 @@
 {
-  "id": "bundle--bf35a4b5-e102-463d-9105-4d7a6e2d78bc",
-  "objects": [
-    {
-      "created": "2014-05-08T09:00:00.000Z",
-      "id": "campaign--c831ab93-ff84-9cda-2bd8-b094004da969",
-      "modified": "2014-05-08T09:00:00.000Z",
-      "name": "Operation Alpha",
-      "type": "campaign"
-    },
-    {
-      "created": "2014-05-08T09:00:00.000Z",
-      "description": "Targets",
-      "id": "relationship--88d1b107-8a5e-4329-ba81-937fecfaa637",
-      "modified": "2014-05-08T09:00:00.000Z",
-      "relationship_type": "uses",
-      "source_ref": "campaign--c831ab93-ff84-9cda-2bd8-b094004da969",
-      "type": "relationship"
-    }
-  ],
-  "spec_version": "2.0",
-  "type": "bundle"
+    "id": "bundle--bf35a4b5-e102-463d-9105-4d7a6e2d78bc",
+    "objects": [
+        {
+            "created": "2014-05-08T09:00:00.000Z",
+            "id": "campaign--c831ab93-ff84-9cda-2bd8-b094004da969",
+            "modified": "2014-05-08T09:00:00.000Z",
+            "name": "Operation Alpha",
+            "type": "campaign"
+        },
+        {
+            "created": "2014-05-08T09:00:00.000Z",
+            "id": "identity--4fde045a-b25f-f035-e8d0-29c9d5130cd9",
+            "identity_class": "unknown",
+            "modified": "2014-05-08T09:00:00.000Z",
+            "name": "Victim Targeting: Customer PII and Financial Data",
+            "type": "identity",
+            "x_elevator_targeted_information": [
+                "Information Assets - Customer PII",
+                "Information Assets - Financial Data"
+            ]
+        },
+        {
+            "created": "2014-05-08T09:00:00.000Z",
+            "description": "Targets",
+            "id": "relationship--09ae7018-6967-4436-8599-d9f9cbffc58f",
+            "modified": "2014-05-08T09:00:00.000Z",
+            "relationship_type": "targets",
+            "source_ref": "campaign--c831ab93-ff84-9cda-2bd8-b094004da969",
+            "target_ref": "identity--4fde045a-b25f-f035-e8d0-29c9d5130cd9",
+            "type": "relationship"
+        }
+    ],
+    "spec_version": "2.0",
+    "type": "bundle"
 }

--- a/idioms-json-2.1-custom/incident-malware.json
+++ b/idioms-json-2.1-custom/incident-malware.json
@@ -3,7 +3,7 @@
     "objects": [
         {
             "created": "2014-05-08T09:00:00.000Z",
-            "id": "identity--3b473523-cc54-4dde-8db8-336e1f1b91c4",
+            "id": "identity--985d726f-889f-48cf-b6b4-e31f562733cd",
             "modified": "2014-05-08T09:00:00.000Z",
             "name": "Fred",
             "spec_version": "2.1",
@@ -11,24 +11,24 @@
         },
         {
             "created": "2014-05-08T09:00:00.000Z",
-            "id": "identity--934411d5-522e-44f7-ab3b-c935f729fc03",
+            "id": "identity--6f61e6f6-c980-43be-aafb-fca7a462caf5",
             "modified": "2014-05-08T09:00:00.000Z",
             "name": "Barney",
             "spec_version": "2.1",
             "type": "identity"
         },
         {
+            "contacts": [
+                "identity--985d726f-889f-48cf-b6b4-e31f562733cd",
+                "identity--6f61e6f6-c980-43be-aafb-fca7a462caf5"
+            ],
             "created": "2014-05-08T09:00:00.000Z",
             "id": "incident--1b75ee8f-44d6-819a-d729-09ab52c91fdb",
             "modified": "2014-05-08T09:00:00.000Z",
             "name": "Detected Poison Ivy beaconing through perimeter firewalls",
             "spec_version": "2.1",
-            "type": "incident",
-            "x_elevator_contacts": [
-                "identity--3b473523-cc54-4dde-8db8-336e1f1b91c4",
-                "identity--934411d5-522e-44f7-ab3b-c935f729fc03"
-            ],
-            "x_elevator_status": "New"
+            "status": "New",
+            "type": "incident"
         },
         {
             "created": "2014-05-08T09:00:00.000Z",
@@ -46,7 +46,7 @@
         {
             "created": "2014-05-08T09:00:00.000Z",
             "description": "Uses Malware",
-            "id": "relationship--58c4ff20-be27-45b6-a253-72ecc8d70e0a",
+            "id": "relationship--b51a785b-5bc4-4172-9c76-f7fe25c6d6d9",
             "modified": "2014-05-08T09:00:00.000Z",
             "relationship_type": "related-to",
             "source_ref": "incident--1b75ee8f-44d6-819a-d729-09ab52c91fdb",

--- a/idioms-json-2.1-valid/block-network-traffic.json
+++ b/idioms-json-2.1-valid/block-network-traffic.json
@@ -2,13 +2,25 @@
     "id": "bundle--495c4c04-b5d8-11e3-b7bb-000c29789db9",
     "objects": [
         {
-            "created": "2017-01-27T13:49:41.298Z",
-            "description": "\n\nSTAGE:\n\tResponse\n\nOBJECTIVE: Block communication between the PIVY agents and the C2 Server\n\nCONFIDENCE: High\n\nIMPACT:LowThis IP address is not used for legitimate hosting so there should be no operational impact.\n\nCOST:Low\n\nEFFICACY:High",
+            "created": "2019-10-04T13:10:29.813Z",
+            "extensions": {
+                "extension-definition--a46b18de-0b41-4a95-9d2d-67a360f2d859": {
+                    "cost": "Low",
+                    "efficacy": "High",
+                    "extension_type": "property-extension",
+                    "impact": "Low",
+                    "impact_description": "This IP address is not used for legitimate hosting so there should be no operational impact.",
+                    "objective": "Block communication between the PIVY agents and the C2 Server",
+                    "objective_confidence": "High",
+                    "parameter_expression": "ipv4-addr:value = '10.10.10.10'",
+                    "stage": "Response"
+                }
+            },
             "id": "course-of-action--495c9b28-b5d8-11e3-b7bb-000c29789db9",
             "labels": [
                 "perimeter-blocking"
             ],
-            "modified": "2017-01-27T13:49:41.298Z",
+            "modified": "2019-10-04T13:10:29.813Z",
             "name": "Block traffic to PIVY C2 Server (10.10.10.10)",
             "spec_version": "2.1",
             "type": "course-of-action"

--- a/idioms-json-2.1-valid/campaign-v-actors.json
+++ b/idioms-json-2.1-valid/campaign-v-actors.json
@@ -3,6 +3,23 @@
     "objects": [
         {
             "created": "2014-08-08T15:50:10.983Z",
+            "extensions": {
+                "extension-definition--8f0b8ed7-c7ad-4650-babe-c4c45cac4a0b": {
+                    "extension_type": "property-extension",
+                    "targeted_information": [
+                        "Information Assets - Financial Data"
+                    ]
+                }
+            },
+            "id": "identity--2d1c6ab3-5e4e-48ac-a32b-f0c01c2836a8",
+            "identity_class": "unknown",
+            "modified": "2014-08-08T15:50:10.983Z",
+            "name": "Victim Targeting: Customer PII and Financial Data",
+            "spec_version": "2.1",
+            "type": "identity"
+        },
+        {
+            "created": "2014-08-08T15:50:10.983Z",
             "goals": [
                 "Theft",
                 "Theft - Theft of Proprietary Information"
@@ -20,7 +37,16 @@
                 "NewsBeef"
             ],
             "created": "2014-08-08T15:50:10.983Z",
-            "description": "Fred\n\nINFORMATION SOURCE ROLE: Aggregator\n\nINFORMATION SOURCE ROLE: Initial Author",
+            "description": "Fred",
+            "extensions": {
+                "extension-definition--d83fce45-ef58-4c6c-a3f4-1fbc32e98c6e": {
+                    "extension_type": "property-extension",
+                    "information_source_roles": [
+                        "Aggregator",
+                        "Initial Author"
+                    ]
+                }
+            },
             "external_references": [
                 {
                     "source_name": "unknown",
@@ -35,7 +61,17 @@
         },
         {
             "created": "2014-08-08T15:50:10.983Z",
-            "id": "relationship--2ae13256-e6bb-4960-903a-63683c1df05a",
+            "id": "relationship--c6ad8a94-edd3-4625-b5b3-24061c615a4b",
+            "modified": "2014-08-08T15:50:10.983Z",
+            "relationship_type": "targets",
+            "source_ref": "campaign--e5268b6e-4931-42f1-b379-87f48eb41b1e",
+            "spec_version": "2.1",
+            "target_ref": "identity--2d1c6ab3-5e4e-48ac-a32b-f0c01c2836a8",
+            "type": "relationship"
+        },
+        {
+            "created": "2014-08-08T15:50:10.983Z",
+            "id": "relationship--5dcfc21e-c88c-4a3b-b68a-9d207995b0c8",
             "modified": "2014-08-08T15:50:10.983Z",
             "relationship_type": "attributed-to",
             "source_ref": "incident--229ab6ba-0eb2-415b-bdf2-079e6b42f51e",
@@ -45,7 +81,7 @@
         },
         {
             "created": "2014-08-08T15:50:10.983Z",
-            "id": "relationship--55662552-faf8-43b5-8a25-18a639c748ce",
+            "id": "relationship--66602cba-bf53-4d70-a8c3-83f089f6b693",
             "modified": "2014-08-08T15:50:10.983Z",
             "relationship_type": "attributed-to",
             "source_ref": "incident--517cf274-038d-4ed4-a3ec-3ac18ad9db8a",
@@ -55,7 +91,7 @@
         },
         {
             "created": "2014-08-08T15:50:10.983Z",
-            "id": "relationship--1cec8c59-4d36-4f70-ba38-d800262f396d",
+            "id": "relationship--7611b8f0-5869-495f-9a97-ff5b81d95d03",
             "modified": "2014-08-08T15:50:10.983Z",
             "relationship_type": "attributed-to",
             "source_ref": "incident--7d8cf96f-91cb-42d0-a1e0-bfa38ea08621",
@@ -65,7 +101,7 @@
         },
         {
             "created": "2014-08-08T15:50:10.983Z",
-            "id": "relationship--3dcf59c3-30e3-4aa5-9c05-2cbffcee5922",
+            "id": "relationship--6a592f33-f088-4211-860a-9121bd5059b6",
             "modified": "2014-08-08T15:50:10.983Z",
             "relationship_type": "attributed-to",
             "source_ref": "campaign--e5268b6e-4931-42f1-b379-87f48eb41b1e",

--- a/idioms-json-2.1-valid/custom_object.json
+++ b/idioms-json-2.1-valid/custom_object.json
@@ -1,0 +1,79 @@
+{
+    "id": "bundle--cad0c65f-3415-4ec6-84df-c01e427ec3b6",
+    "objects": [
+        {
+            "created": "2015-07-31T11:24:39.090Z",
+            "extensions": {
+                "extension-definition--a46b18de-0b41-4a95-9d2d-67a360f2d859": {
+                    "extension_type": "property-extension",
+                    "impact": "Medium",
+                    "impact_description": "Some description about the indicator.",
+                    "objective": "Block outbound traffic",
+                    "objective_confidence": "High",
+                    "stage": "Response"
+                }
+            },
+            "id": "course-of-action--3dbfccad-1fbb-4e9f-8307-f2d1a5c651cc",
+            "labels": [
+                "perimeter-blocking"
+            ],
+            "modified": "2015-07-31T11:24:39.090Z",
+            "name": "Block outbound traffic",
+            "spec_version": "2.1",
+            "type": "course-of-action"
+        },
+        {
+            "created": "2015-07-31T11:24:39.090Z",
+            "extensions": {
+                "extension-definition--7c8ca481-f0e9-4389-94f5-90df472eb01d": {
+                    "extension_type": "property-extension",
+                    "likely_impact": "Medium"
+                }
+            },
+            "id": "indicator--2cb76e88-2734-4a6c-a28c-52ae05f627be",
+            "indicator_types": [
+                "ftp"
+            ],
+            "modified": "2015-07-31T11:24:39.090Z",
+            "pattern": "[x-elevator-fooz:ftp_command MATCHES 'fp[a-zA-Z0-9]{44}\\\\.bin']",
+            "pattern_type": "stix",
+            "spec_version": "2.1",
+            "type": "indicator",
+            "valid_from": "2015-07-31T11:24:39.090000Z"
+        },
+        {
+            "created": "2015-07-31T11:24:39.090Z",
+            "id": "relationship--b7e4e7c3-36b6-4e93-bc47-e6e65fc21168",
+            "modified": "2015-07-31T11:24:39.090Z",
+            "relationship_type": "investigates",
+            "source_ref": "course-of-action--3dbfccad-1fbb-4e9f-8307-f2d1a5c651cc",
+            "spec_version": "2.1",
+            "target_ref": "indicator--2cb76e88-2734-4a6c-a28c-52ae05f627be",
+            "type": "relationship"
+        },
+        {
+            "extensions": {
+                "extension-definition--88b426e6-6704-4b7e-b564-bff6375a9077": {
+                    "extension_type": "new-sco"
+                }
+            },
+            "ftp_command": "fpuwe8bmsD56ns.bin",
+            "id": "fooz--e2c4958a-f74e-42a0-b9d6-55f744adb228",
+            "type": "fooz"
+        },
+        {
+            "created": "2015-07-31T11:24:39.090Z",
+            "first_observed": "2015-07-31T11:24:39.090Z",
+            "id": "observed-data--b6a16349-c7ae-463e-9b74-8fd81efb14b7",
+            "last_observed": "2015-07-31T11:24:39.090Z",
+            "modified": "2015-07-31T11:24:39.090Z",
+            "number_observed": 1,
+            "object_refs": [
+                "fooz--e2c4958a-f74e-42a0-b9d6-55f744adb228"
+            ],
+            "spec_version": "2.1",
+            "type": "observed-data"
+        }
+    ],
+    "type": "bundle"
+}

--- a/idioms-json-2.1-valid/cve-in-exploit-target.json
+++ b/idioms-json-2.1-valid/cve-in-exploit-target.json
@@ -3,14 +3,24 @@
     "objects": [
         {
             "created": "2014-05-08T09:00:00.000Z",
-            "description": "\n\nSOURCE:\n\tMITRE\n\nDISCOVERED_DATETIME:\n\t2013-09-18T06:06:47.000000Z",
+            "extensions": {
+                "extension-definition--ac577b78-8356-41e0-bc5a-2cd3e5c17b2c": {
+                    "discovered_datetime": "2013-09-18T06:06:47.000000Z",
+                    "extension_type": "property-extension",
+                    "source": "MITRE"
+                }
+            },
             "external_references": [
                 {
                     "external_id": "CVE-2013-3893",
                     "source_name": "cve"
+                },
+                {
+                    "source_name": "internet_resource",
+                    "url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-4878"
                 }
             ],
-            "id": "vulnerability--b4b14336-9743-40c8-a070-b205531ddbc0",
+            "id": "vulnerability--abc80d31-5d22-4f07-b497-afba8e936f8f",
             "modified": "2014-05-08T09:00:00.000Z",
             "name": "Javascript vulnerability in MSIE 6-11",
             "spec_version": "2.1",

--- a/idioms-json-2.1-valid/file-and-directory.json
+++ b/idioms-json-2.1-valid/file-and-directory.json
@@ -16,8 +16,13 @@
             "type": "directory"
         },
         {
-            "id": "x-windows-hook--156fa3a8-01e9-44a2-a1f3-59738767179c",
-            "type": "x-windows-hook",
+            "extensions": {
+                "extension-definition--b8bf4445-a56c-468d-8b57-1d15f74776c6": {
+                    "extension_type": "new-sco"
+                }
+            },
+            "id": "windows-hook--1e114dc8-aec0-4507-9e56-8078464a6274",
+            "type": "windows-hook",
             "win-hook-type": "WH_KEYBOARD_LL"
         },
         {

--- a/idioms-json-2.1-valid/file-hash-reputation.json
+++ b/idioms-json-2.1-valid/file-hash-reputation.json
@@ -1,21 +1,21 @@
 {
-  "id": "bundle--bc2955f8-f1bb-4f02-b2ed-339d7daf6d75",
-  "objects": [
-    {
-      "created": "2015-07-20T19:52:13.853Z",
-      "description": "\n\nCONFIDENCE: 75",
-      "id": "indicator--14975dea-86cd-4211-a5f8-9c2e4daab69a",
-      "indicator_types": [
-        "file-hash-watchlist"
-      ],
-      "modified": "2015-07-20T19:52:13.853Z",
-      "name": "File Reputation for SHA256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "pattern": "[file:hashes.'SHA-256' = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855']",
-      "pattern_type": "stix",
-      "spec_version": "2.1",
-      "type": "indicator",
-      "valid_from": "2015-07-20T19:52:13.853585Z"
-    }
-  ],
-  "type": "bundle"
+    "id": "bundle--bc2955f8-f1bb-4f02-b2ed-339d7daf6d75",
+    "objects": [
+        {
+            "confidence": 75,
+            "created": "2015-07-20T19:52:13.853Z",
+            "id": "indicator--14975dea-86cd-4211-a5f8-9c2e4daab69a",
+            "indicator_types": [
+                "file-hash-watchlist"
+            ],
+            "modified": "2015-07-20T19:52:13.853Z",
+            "name": "File Reputation for SHA256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "pattern": "[file:hashes.'SHA-256' = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855']",
+            "pattern_type": "stix",
+            "spec_version": "2.1",
+            "type": "indicator",
+            "valid_from": "2015-07-20T19:52:13.853585Z"
+        }
+    ],
+    "type": "bundle"
 }

--- a/idioms-json-2.1-valid/fix-embedded-relationship-example.json
+++ b/idioms-json-2.1-valid/fix-embedded-relationship-example.json
@@ -2,36 +2,36 @@
     "id": "bundle--161f8ade-b67d-11e3-b8af-f01faf20d111",
     "objects": [
         {
-            "created": "2017-01-27T13:49:53.872Z",
+            "created": "2019-10-04T13:10:53.526Z",
             "id": "identity--4ec4d0a2-80e3-11e6-ae22-56b6b6499611",
             "identity_class": "unknown",
-            "modified": "2017-01-27T13:49:53.872Z",
+            "modified": "2019-10-04T13:10:53.526Z",
             "name": "Emmanuelle",
             "spec_version": "2.1",
             "type": "identity"
         },
         {
-            "created": "2017-01-27T13:49:53.872Z",
+            "created": "2019-10-04T13:10:53.526Z",
             "created_by_ref": "identity--4ec4d0a2-80e3-41e6-ae22-56b6b6499611",
             "id": "identity--1621d4d4-b67d-11e3-9670-f01faf20d111",
             "identity_class": "unknown",
-            "modified": "2017-01-27T13:49:53.872Z",
+            "modified": "2019-10-04T13:10:53.526Z",
             "name": "Adversary Bravo",
             "spec_version": "2.1",
             "type": "identity"
         },
         {
-            "created": "2017-01-27T13:49:53.872Z",
+            "created": "2019-10-04T13:10:53.526Z",
             "created_by_ref": "identity--4ec4d0a2-80e3-11e6-ae22-56b6b6499611",
             "id": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f",
-            "modified": "2017-01-27T13:49:53.872Z",
+            "modified": "2019-10-04T13:10:53.526Z",
             "name": "Adversary Bravo",
             "sophistication": "unknown",
             "spec_version": "2.1",
             "type": "threat-actor"
         },
         {
-            "created": "2017-01-27T13:49:53.872Z",
+            "created": "2019-10-04T13:10:53.526Z",
             "created_by_ref": "identity--4ec4d0a2-80e3-11e6-ae22-56b6b6499611",
             "description": "Phishing",
             "external_references": [
@@ -41,29 +41,34 @@
                 }
             ],
             "id": "attack-pattern--8ac90ff3-ecf8-4835-95b8-6aea6a623df5",
-            "modified": "2017-01-27T13:49:53.872Z",
+            "modified": "2019-10-04T13:10:53.526Z",
             "name": "Phishing",
             "spec_version": "2.1",
             "type": "attack-pattern"
         },
         {
-            "created": "2017-01-27T13:49:53.872Z",
-            "description": "\n\nTITLE:\n\tPoison Ivy Variant d1c6",
+            "created": "2019-10-04T13:10:53.526Z",
+            "extensions": {
+                "extension-definition--5efa53f9-cf17-4867-bb4f-4cd2ac055e7c": {
+                    "extension_type": "property-extension",
+                    "title": "Poison Ivy Variant d1c6"
+                }
+            },
             "id": "malware--1621d4d2-b67d-11e3-ba9e-f01faf20d111",
             "is_family": false,
             "malware_types": [
                 "remote-access-trojan"
             ],
-            "modified": "2017-01-27T13:49:53.872Z",
+            "modified": "2019-10-04T13:10:53.526Z",
             "name": "Poison Ivy Variant d1c6",
             "spec_version": "2.1",
             "type": "malware"
         },
         {
-            "created": "2017-01-27T13:49:53.872Z",
+            "created": "2019-10-04T13:10:53.526Z",
             "created_by_ref": "identity--4ec4d0a2-80e3-11e6-ae22-56b6b6499611",
             "id": "relationship--1621d4d4-b67d-11e3-9670-f01faf20d111",
-            "modified": "2017-01-27T13:49:53.872Z",
+            "modified": "2019-10-04T13:10:53.526Z",
             "relationship_type": "attributed-to",
             "source_ref": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f",
             "spec_version": "2.1",
@@ -71,11 +76,11 @@
             "type": "relationship"
         },
         {
-            "created": "2017-01-27T13:49:53.872Z",
+            "created": "2019-10-04T13:10:53.526Z",
             "created_by_ref": "identity--4ec4d0a2-80e3-11e6-ae22-56b6b6499611",
             "description": "Leverages Attack Pattern",
-            "id": "relationship--e20d22c1-9141-4c1a-9804-dd79cb0f2069",
-            "modified": "2017-01-27T13:49:53.872Z",
+            "id": "relationship--cc5cc87e-82e6-4080-ac74-dbc8be6ac7aa",
+            "modified": "2019-10-04T13:10:53.526Z",
             "relationship_type": "uses",
             "source_ref": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f",
             "spec_version": "2.1",
@@ -83,11 +88,11 @@
             "type": "relationship"
         },
         {
-            "created": "2017-01-27T13:49:53.872Z",
+            "created": "2019-10-04T13:10:53.526Z",
             "created_by_ref": "identity--4ec4d0a2-80e3-11e6-ae22-56b6b6499611",
             "description": "Leverages Malware",
-            "id": "relationship--bb9df45d-ec36-493f-ba29-ad5563818cd3",
-            "modified": "2017-01-27T13:49:53.872Z",
+            "id": "relationship--bfa57adf-f86a-420a-9420-9b55c761c348",
+            "modified": "2019-10-04T13:10:53.526Z",
             "relationship_type": "uses",
             "source_ref": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f",
             "spec_version": "2.1",

--- a/idioms-json-2.1-valid/incident-malware.json
+++ b/idioms-json-2.1-valid/incident-malware.json
@@ -1,18 +1,70 @@
 {
-    "id": "bundle--65184e82-b693-11e3-bfd7-0800271e87d2",
+    "id": "bundle--65184e82-b693-41e3-bfd7-0800271e87d2",
     "objects": [
         {
-            "created": "2017-01-27T13:49:53.888Z",
-            "description": "\n\nTITLE:\n\tPoison Ivy",
-            "id": "malware--6516102d-b693-11e3-bfd7-0800271e87d2",
+            "created": "2014-05-08T09:00:00.000Z",
+            "id": "identity--6aedbecd-7323-4308-9cac-8fc71b9e10d2",
+            "identity_class": "unknown",
+            "modified": "2014-05-08T09:00:00.000Z",
+            "name": "Fred",
+            "spec_version": "2.1",
+            "type": "identity"
+        },
+        {
+            "created": "2014-05-08T09:00:00.000Z",
+            "id": "identity--f854887d-9e74-4e95-a2a0-f79af678768e",
+            "identity_class": "unknown",
+            "modified": "2014-05-08T09:00:00.000Z",
+            "name": "Barney",
+            "spec_version": "2.1",
+            "type": "identity"
+        },
+        {
+            "created": "2014-05-08T09:00:00.000Z",
+            "extensions": {
+                "extension-definition--7a8eaf47-9b0f-487d-b280-1e6cc4cccee9": {
+                    "contacts": [
+                        "identity--6aedbecd-7323-4308-9cac-8fc71b9e10d2",
+                        "identity--f854887d-9e74-4e95-a2a0-f79af678768e"
+                    ],
+                    "extension_type": "property-extension",
+                    "spec_version": "2.1",
+                    "status": "New"
+                }
+            },
+            "id": "incident--1b75ee8f-44d6-819a-d729-09ab52c91fdb",
+            "modified": "2014-05-08T09:00:00.000Z",
+            "name": "Detected Poison Ivy beaconing through perimeter firewalls",
+            "type": "incident"
+        },
+        {
+            "created": "2014-05-08T09:00:00.000Z",
+            "extensions": {
+                "extension-definition--5efa53f9-cf17-4867-bb4f-4cd2ac055e7c": {
+                    "extension_type": "property-extension",
+                    "title": "Poison Ivy"
+                }
+            },
+            "id": "malware--6516102d-b693-41e3-bfd7-0800271e87d2",
             "is_family": false,
             "malware_types": [
                 "remote-access-trojan"
             ],
-            "modified": "2017-01-27T13:49:53.888Z",
+            "modified": "2014-05-08T09:00:00.000Z",
             "name": "Poison Ivy",
             "spec_version": "2.1",
             "type": "malware"
+        },
+        {
+            "created": "2014-05-08T09:00:00.000Z",
+            "description": "Uses Malware",
+            "id": "relationship--dfc77494-4990-4d86-a4fc-0a20963fe6e2",
+            "modified": "2014-05-08T09:00:00.000Z",
+            "relationship_type": "related-to",
+            "source_ref": "incident--1b75ee8f-44d6-819a-d729-09ab52c91fdb",
+            "spec_version": "2.1",
+            "target_ref": "malware--6516102d-b693-41e3-bfd7-0800271e87d2",
+            "type": "relationship"
         }
     ],
     "type": "bundle"

--- a/idioms-json-2.1-valid/issue62.json
+++ b/idioms-json-2.1-valid/issue62.json
@@ -1,73 +1,70 @@
 {
-    "id": "bundle--6116aed6-a7e9-11e3-a82f-000c29b241af",
+    "id": "bundle--6116aed6-a7e9-41e3-a82f-000c29b241af",
     "objects": [
         {
-            "created": "2018-07-30T13:03:43.987Z",
-            "id": "indicator--6116b44e-a7e9-11e3-a82f-000c29b241af",
-            "modified": "2018-07-30T13:03:43.987Z",
-            "pattern": "[((file:hashes.MD5 = '5d8129be965fab8115eca34fc84bd7f0' OR file:hashes.'SHA-1' = '2b999e7db890cc77f0098a091de756a1803a3c2b' OR file:hashes.'SHA-256' = '2c5dd8a64437cb2dd4b6747139c61d2d7f53ab3ddedbf22df3cb01bae170715b' OR file:hashes.ssdeep = '768:mvAFYk0IOqi7RKW1RD1ZCrm82+AnbaAOdoOKL70ehP:cDIOqctz2rBmbZoa71hP') AND file:name = 'VirusShare_5d8129be965fab8115eca34fc84bd7f0' AND file:size = 40654 AND (((file:extensions.'windows-pebinary-ext'.sections[*].name = '.rdata' AND file:extensions.'windows-pebinary-ext'.sections[*].entropy = 7.74202363178) AND (file:extensions.'windows-pebinary-ext'.sections[*].name = '.data' AND file:extensions.'windows-pebinary-ext'.sections[*].entropy = 7.89204688601) AND (file:extensions.'windows-pebinary-ext'.sections[*].name = '.upx' AND file:extensions.'windows-pebinary-ext'.sections[*].entropy = 7.31815613066))))]",
+            "created": "2020-02-11T14:25:20.680Z",
+            "id": "indicator--6116b44e-a7e9-41e3-a82f-000c29b241af",
+            "modified": "2020-02-11T14:25:20.680Z",
+            "pattern": "[(file:hashes.MD5 = '5d8129be965fab8115eca34fc84bd7f0' OR file:hashes.'SHA-1' = '2b999e7db890cc77f0098a091de756a1803a3c2b' OR file:hashes.'SHA-256' = '2c5dd8a64437cb2dd4b6747139c61d2d7f53ab3ddedbf22df3cb01bae170715b' OR file:hashes.ssdeep = '768:mvAFYk0IOqi7RKW1RD1ZCrm82+AnbaAOdoOKL70ehP:cDIOqctz2rBmbZoa71hP') AND file:name = 'VirusShare_5d8129be965fab8115eca34fc84bd7f0' AND file:size = 40654 AND (((file:extensions.'windows-pebinary-ext'.sections[*].name = '.rdata' AND file:extensions.'windows-pebinary-ext'.sections[*].x_elevator_entropy_min < 10.0 AND file:extensions.'windows-pebinary-ext'.sections[*].entropy = 7.74202363178) AND (file:extensions.'windows-pebinary-ext'.sections[*].name = '.data' AND file:extensions.'windows-pebinary-ext'.sections[*].entropy = 7.89204688601) AND (file:extensions.'windows-pebinary-ext'.sections[*].name = '.upx' AND file:extensions.'windows-pebinary-ext'.sections[*].entropy = 7.31815613066)) AND file:extensions.'windows-pebinary-ext'.x_elevator_imports[*] = 'GetProcAddress')]",
             "pattern_type": "stix",
             "spec_version": "2.1",
             "type": "indicator",
-            "valid_from": "2018-07-30T13:03:43.987655Z"
+            "valid_from": "2020-02-11T14:25:20.680Z"
         },
         {
-            "created": "2018-07-30T13:03:43.991Z",
-            "id": "indicator--6116cf88-a7e9-11e3-a82f-000c29b241af",
-            "modified": "2018-07-30T13:03:43.991Z",
-            "pattern": "[((file:hashes.MD5 = 'd41d8cd98f00b204e9800998ecf8427e' OR file:hashes.'SHA-1' = 'da39a3ee5e6b4b0d3255bfef95601890afd80709' OR file:hashes.'SHA-256' = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855') AND file:name = 'autoexec.bat' AND file:size = 0)]",
+            "created": "2020-02-11T14:25:20.680Z",
+            "id": "indicator--6116cf88-a7e9-41e3-a82f-000c29b241af",
+            "modified": "2020-02-11T14:25:20.680Z",
+            "pattern": "[(file:hashes.MD5 = 'd41d8cd98f00b204e9800998ecf8427e' OR file:hashes.'SHA-1' = 'da39a3ee5e6b4b0d3255bfef95601890afd80709' OR file:hashes.'SHA-256' = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855') AND file:name = 'autoexec.bat' AND file:size = 0]",
             "pattern_type": "stix",
             "spec_version": "2.1",
             "type": "indicator",
-            "valid_from": "2018-07-30T13:03:43.991158Z"
+            "valid_from": "2020-02-11T14:25:20.680Z"
         },
         {
-            "created": "2018-07-30T13:03:43.992Z",
-            "id": "indicator--6116d730-a7e9-11e3-a82f-000c29b241af",
-            "modified": "2018-08-21T09:30:27.969Z",
-            "pattern": "[(process:pid = 1700 AND process:parent_ref.pid = 1616 AND process:creator_user_ref.user_id = 'admin' AND process:created = t'2010-12-09T20:17:34.934295Z' AND process:command_line = 'bash some.sh') AND process:environment_variables[*].PROXY = '123.456.0.1' AND process:child_refs[*].pid = 4567 AND process:opened_connection_refs[*].dst_ref.value = '198.49.123.10' AND process:extensions.'windows-process-ext'.window_title = 'Some Title']",
+            "created": "2020-02-11T14:25:20.680Z",
+            "id": "indicator--6116d730-a7e9-41e3-a82f-000c29b241af",
+            "modified": "2020-02-11T14:25:20.680Z",
+            "pattern": "[process:pid = 1700 AND process:name = 'VirusShare_5d8129be965fab8115eca34fc84bd7f0' AND process:parent_ref.pid = 1616 AND process:creator_user_ref.user_id = 'admin' AND process:created = t'2010-12-09T20:17:34.934295Z' AND process:command_line = 'bash some.sh' AND (process:arguments[*] = '--p' AND process:arguments[*] = 'some_file.txt') AND process:environment_variables[*].PROXY = '123.456.0.1' AND process:child_refs[*].pid = 4567 AND process:opened_connection_refs[*].dst_ref.value = '198.49.123.10' AND process:extensions.'windows-process-ext'.window_title = 'Some Title']",
             "pattern_type": "stix",
             "spec_version": "2.1",
             "type": "indicator",
-            "valid_from": "2018-07-30T13:03:43.992158Z"
+            "valid_from": "2020-02-11T14:25:20.680Z"
         },
         {
-            "created": "2018-07-30T13:03:43.992Z",
-            "id": "indicator--6116dcbc-a7e9-11e3-a82f-000c29b241af",
-            "modified": "2018-07-30T13:03:43.992Z",
-            "pattern": "[(windows-registry-key:key = 'HKEY_CURRENT_USER\\\\Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Explorer\\\\User Shell Folders' AND windows-registry-key:key = 'HKEY_CURRENT_USER\\\\Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Explorer\\\\Shell Folders' AND windows-registry-key:key = 'HKEY_LOCAL_MACHINE\\\\Software\\\\Microsoft\\\\Tracing' AND windows-registry-key:key = 'HKEY_LOCAL_MACHINE\\\\Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Explorer\\\\User Shell Folders' AND windows-registry-key:key = 'Software\\\\Microsoft\\\\Windows NT\\\\CurrentVersion\\\\Winlogon' AND windows-registry-key:key = 'HKEY_LOCAL_MACHINE\\\\Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Explorer\\\\Shell Folders' AND windows-registry-key:key = 'Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Explorer\\\\User Shell Folders' AND windows-registry-key:key = 'Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Explorer\\\\Shell Folders' AND windows-registry-key:key = 'Software\\\\Microsoft\\\\windows\\\\CurrentVersion\\\\Internet Settings' AND windows-registry-key:key = 'Software\\\\Microsoft\\\\windows\\\\CurrentVersion\\\\Internet Settings\\\\Connections' AND windows-registry-key:key = 'HKEY_CURRENT_CONFIG\\\\Software\\\\Microsoft\\\\windows\\\\CurrentVersion\\\\Internet Settings' AND windows-registry-key:key = 'Software\\\\Microsoft\\\\SystemCertificates\\\\MY' AND windows-registry-key:key = 'HKEY_LOCAL_MACHINE\\\\System\\\\CurrentControlSet\\\\Services\\\\Tcpip\\\\Parameters')]",
+            "created": "2020-02-11T14:25:20.680Z",
+            "id": "indicator--6116dcbc-a7e9-41e3-a82f-000c29b241af",
+            "modified": "2020-02-11T14:25:20.680Z",
+            "pattern": "[windows-registry-key:key = 'HKEY_CURRENT_USER\\\\Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Explorer\\\\User Shell Folders'] AND [windows-registry-key:key = 'HKEY_CURRENT_USER\\\\Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Explorer\\\\Shell Folders'] AND [windows-registry-key:key = 'HKEY_LOCAL_MACHINE\\\\Software\\\\Microsoft\\\\Tracing'] AND [windows-registry-key:key = 'HKEY_LOCAL_MACHINE\\\\Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Explorer\\\\User Shell Folders'] AND [windows-registry-key:key = 'Software\\\\Microsoft\\\\Windows NT\\\\CurrentVersion\\\\Winlogon'] AND [windows-registry-key:key = 'HKEY_LOCAL_MACHINE\\\\Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Explorer\\\\Shell Folders'] AND [windows-registry-key:key = 'Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Explorer\\\\User Shell Folders'] AND [windows-registry-key:key = 'Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Explorer\\\\Shell Folders'] AND [windows-registry-key:key = 'Software\\\\Microsoft\\\\windows\\\\CurrentVersion\\\\Internet Settings'] AND [windows-registry-key:key = 'Software\\\\Microsoft\\\\windows\\\\CurrentVersion\\\\Internet Settings\\\\Connections'] AND [windows-registry-key:key = 'HKEY_CURRENT_CONFIG\\\\Software\\\\Microsoft\\\\windows\\\\CurrentVersion\\\\Internet Settings'] AND [windows-registry-key:key = 'Software\\\\Microsoft\\\\SystemCertificates\\\\MY'] AND [windows-registry-key:key = 'HKEY_LOCAL_MACHINE\\\\System\\\\CurrentControlSet\\\\Services\\\\Tcpip\\\\Parameters']",
             "pattern_type": "stix",
             "spec_version": "2.1",
             "type": "indicator",
-            "valid_from": "2018-08-21T09:30:27.972376Z"
+            "valid_from": "2020-02-11T14:25:20.680Z"
         },
         {
             "child_refs": [
-                "process--8aaf51b1-92ae-4c2b-9d13-4e917dc49ec8"
+                "process--c543f7bd-8e5e-4322-b8cf-7e35dcb15b0c"
             ],
-            "created": "2010-12-09T20:17:34.934295Z",
+            "created_time": "2010-12-09T20:17:34.934295Z",
+            "creator_user_ref": "user-account--4c042077-1456-5191-94a6-0e90b7bd9b05",
             "extensions": {
                 "windows-process-ext": {
                     "window_title": "Some Title"
                 }
             },
-            "id": "process--63e1e0f5-3355-4ac5-b54a-d83eb006885a",
+            "id": "process--8146188c-fe64-4491-91e4-17937b39e410",
             "opened_connection_refs": [
-                "network-traffic--f5846e0a-a789-52b4-babb-24eb6c5d7309"
+                "network-traffic--a5b3dc59-35ad-5731-bae9-48f078efdea6"
             ],
-            "parent_ref": "process--d1a4c3df-4dfc-420b-9f05-e5a208afb25d",
+            "parent_ref": "process--f5a8ee13-9e00-464a-8539-9e819c281d14",
             "pid": 1700,
             "type": "process"
         },
         {
-            "id": "process--8aaf51b1-92ae-4c2b-9d13-4e917dc49ec8",
-            "pid": 4567,
-            "type": "process"
-        },
-        {
-            "id": "process--d1a4c3df-4dfc-420b-9f05-e5a208afb25d",
-            "pid": 1616,
-            "type": "process"
+            "dst_port": 80,
+            "dst_ref": "network-traffic--a5b3dc59-35ad-5731-bae9-48f078efdea6",
+            "id": "network-traffic--a5b3dc59-35ad-5731-bae9-48f078efdea6",
+            "type": "network-traffic"
         },
         {
             "id": "ipv4-addr--96d215a5-eb23-527a-ae22-9507313d32ca",
@@ -75,24 +72,34 @@
             "value": "198.49.123.10"
         },
         {
-            "dst_port": 80,
-            "dst_ref": "ipv4-addr--96d215a5-eb23-527a-ae22-9507313d32ca",
-            "id": "network-traffic--f5846e0a-a789-52b4-babb-24eb6c5d7309",
-            "type": "network-traffic"
+            "id": "user-account--4c042077-1456-5191-94a6-0e90b7bd9b05",
+            "type": "user-account",
+            "user_id": "admin"
         },
         {
-            "created": "2018-08-21T09:30:27.964Z",
-            "first_observed": "2018-08-21T09:30:27.964Z",
+            "id": "process--c543f7bd-8e5e-4322-b8cf-7e35dcb15b0c",
+            "pid": 4567,
+            "type": "process"
+        },
+        {
+            "id": "process--f5a8ee13-9e00-464a-8539-9e819c281d14",
+            "pid": 1616,
+            "type": "process"
+        },
+        {
+            "created": "2020-02-11T14:25:20.680Z",
+            "first_observed": "2020-02-11T14:25:20.680Z",
             "id": "observed-data--65492fbc-5d48-49bf-83b8-33c965e36066",
-            "last_observed": "2018-08-21T09:30:27.964Z",
-            "modified": "2018-08-21T09:30:27.964Z",
+            "last_observed": "2020-02-11T14:25:20.680Z",
+            "modified": "2020-02-11T14:25:20.680Z",
             "number_observed": 1,
             "object_refs": [
-                "process--63e1e0f5-3355-4ac5-b54a-d83eb006885a",
-                "process--8aaf51b1-92ae-4c2b-9d13-4e917dc49ec8",
-                "process--d1a4c3df-4dfc-420b-9f05-e5a208afb25d",
+                "process--8146188c-fe64-4491-91e4-17937b39e410",
+                "network-traffic--a5b3dc59-35ad-5731-bae9-48f078efdea6",
                 "ipv4-addr--96d215a5-eb23-527a-ae22-9507313d32ca",
-                "network-traffic--f5846e0a-a789-52b4-babb-24eb6c5d7309"
+                "user-account--4c042077-1456-5191-94a6-0e90b7bd9b05",
+                "process--c543f7bd-8e5e-4322-b8cf-7e35dcb15b0c",
+                "process--f5a8ee13-9e00-464a-8539-9e819c281d14"
             ],
             "spec_version": "2.1",
             "type": "observed-data"

--- a/idioms-json-2.1-valid/malicious-email-indicator-with-addresses.json
+++ b/idioms-json-2.1-valid/malicious-email-indicator-with-addresses.json
@@ -1,29 +1,71 @@
 {
-  "id": "bundle--8b8ed1c1-f01d-4393-ac65-97017ed15876",
-  "objects": [
-    {
-      "created": "2014-10-31T15:52:13.126Z",
-      "id": "indicator--b06b0eb7-61dd-4338-a094-0290c380fbd8",
-      "indicator_types": [
-        "malicious-email"
-      ],
-      "modified": "2014-10-31T15:52:13.126Z",
-      "name": "Malicious E-mail Addresses",
-      "pattern": "[(email-message:from_ref.value = 'fred@abc.com' AND (email-message:to_refs[*].value = 'barney@abc.com' OR email-message:to_refs[*].value = 'wilma@abc.com'))]",
-      "pattern_type": "stix",
-      "type": "indicator",
-      "spec_version": "2.1",
-      "valid_from": "2014-10-31T15:52:13.126999Z"
-    },
-    {
-      "created": "2014-10-31T15:52:13.126Z",
-      "id": "relationship--67b8cf7b-f8b1-4df5-8903-ab9028b098f7",
-      "modified": "2014-10-31T15:52:13.126Z",
-      "relationship_type": "indicates",
-      "source_ref": "indicator--b06b0eb7-61dd-4338-a094-0290c380fbd8",
-      "spec_version": "2.1",
-      "type": "relationship"
-    }
-  ],
-  "type": "bundle"
+    "id": "bundle--8b8ed1c1-f01d-4393-ac65-97017ed15876",
+    "objects": [
+        {
+            "confidence": 15,
+            "created": "2014-10-31T15:52:13.126Z",
+            "id": "indicator--b06b0eb7-61dd-4338-a094-0290c380fbd8",
+            "indicator_types": [
+                "malicious-email"
+            ],
+            "modified": "2014-10-31T15:52:13.126Z",
+            "name": "Malicious E-mail Addresses",
+            "pattern": "[email-message:from_ref.value IN ('fred@abc.com', 'betty@abc.com') AND (email-message:to_refs[*].value = 'barney@abc.com' OR email-message:to_refs[*].value = 'wilma@abc.com') AND email-message:message_id = '20131031123417.u1BKfrXh004925@mail-gw-01.abc.com']",
+            "pattern_type": "stix",
+            "spec_version": "2.1",
+            "type": "indicator",
+            "valid_from": "2014-10-31T15:52:13.126999Z"
+        },
+        {
+            "created": "2014-10-31T15:52:13.126Z",
+            "id": "relationship--acbdcc6e-1ba3-47de-97d9-3a160ca9fdaa",
+            "modified": "2014-10-31T15:52:13.126Z",
+            "relationship_type": "indicates",
+            "source_ref": "indicator--b06b0eb7-61dd-4338-a094-0290c380fbd8",
+            "spec_version": "2.1",
+            "type": "relationship"
+        },
+        {
+            "from_ref": "email-addr--bc2a920c-1b53-5abf-b42c-86ff94037f7f",
+            "id": "email-message--ff57c042-04de-5872-9c27-e7e2b750f75c",
+            "is_multipart": false,
+            "to_refs": [
+                "email-addr--a8a46314-8fe6-59f5-9a42-85ba5c9bd6fb",
+                "email-addr--03dd34f1-adba-578b-8109-d91eb868044c"
+            ],
+            "type": "email-message"
+        },
+        {
+            "id": "email-addr--bc2a920c-1b53-5abf-b42c-86ff94037f7f",
+            "type": "email-addr",
+            "value": "fred@abc.com"
+        },
+        {
+            "id": "email-addr--a8a46314-8fe6-59f5-9a42-85ba5c9bd6fb",
+            "type": "email-addr",
+            "value": "barney@abc.com"
+        },
+        {
+            "id": "email-addr--03dd34f1-adba-578b-8109-d91eb868044c",
+            "type": "email-addr",
+            "value": "wilma@abc.com"
+        },
+        {
+            "created": "2020-06-03T13:04:06.068Z",
+            "first_observed": "2020-06-03T13:04:06.068Z",
+            "id": "observed-data--da84c823-199b-4e76-a4b9-f8565b952979",
+            "last_observed": "2020-06-03T13:04:06.068Z",
+            "modified": "2020-06-03T13:04:06.068Z",
+            "number_observed": 1,
+            "object_refs": [
+                "email-message--ff57c042-04de-5872-9c27-e7e2b750f75c",
+                "email-addr--bc2a920c-1b53-5abf-b42c-86ff94037f7f",
+                "email-addr--a8a46314-8fe6-59f5-9a42-85ba5c9bd6fb",
+                "email-addr--03dd34f1-adba-578b-8109-d91eb868044c"
+            ],
+            "spec_version": "2.1",
+            "type": "observed-data"
+        }
+    ],
+    "type": "bundle"
 }

--- a/idioms-json-2.1-valid/malicious-email-indicator-with-attachment.json
+++ b/idioms-json-2.1-valid/malicious-email-indicator-with-attachment.json
@@ -2,6 +2,7 @@
     "id": "bundle--8b8ed1c1-f01d-4393-ac65-97017ed15876",
     "objects": [
         {
+            "confidence": 85,
             "created": "2014-10-31T15:52:13.127Z",
             "id": "indicator--8cf9236f-1b96-493d-98be-0c1c1e8b62d7",
             "indicator_types": [
@@ -9,13 +10,14 @@
             ],
             "modified": "2014-10-31T15:52:13.127Z",
             "name": "Malicious E-mail",
-            "pattern": "[(email-message:subject MATCHES '^[IMPORTANT] Please Review Before' AND email-message:body_multipart[*].body_raw_ref.name MATCHES '^Final Report*.doc.exe$')]",
+            "pattern": "[email-message:subject MATCHES '^[IMPORTANT] Please Review Before' AND email-message:body_multipart[*].body_raw_ref.name MATCHES '^Final Report*.doc.exe$']",
             "pattern_type": "stix",
             "spec_version": "2.1",
             "type": "indicator",
             "valid_from": "2014-10-31T15:52:13.127931Z"
         },
         {
+            "confidence": 15,
             "created": "2014-10-31T15:52:13.126Z",
             "id": "indicator--b06b0eb7-61dd-4338-a094-0290c380fbd8",
             "indicator_types": [
@@ -30,6 +32,7 @@
             "valid_from": "2014-10-31T15:52:13.126999Z"
         },
         {
+            "confidence": 15,
             "created": "2014-10-31T15:52:13.127Z",
             "id": "indicator--2e17f6fe-3a4d-438a-911a-e509ba1b9933",
             "indicator_types": [
@@ -45,7 +48,7 @@
         },
         {
             "created": "2014-10-31T15:52:13.127Z",
-            "id": "relationship--f50e63f5-fc39-481a-95e0-40eced3ae8f4",
+            "id": "relationship--e341a4f1-f210-4360-b923-a502a63348ce",
             "modified": "2014-10-31T15:52:13.127Z",
             "relationship_type": "indicates",
             "source_ref": "indicator--8cf9236f-1b96-493d-98be-0c1c1e8b62d7",
@@ -54,7 +57,7 @@
         },
         {
             "created": "2014-10-31T15:52:13.126Z",
-            "id": "relationship--769b61c6-859d-4461-ac37-9079c3cce0ab",
+            "id": "relationship--cc2bab61-68f0-43ed-82e4-d2f6db1273c9",
             "modified": "2014-10-31T15:52:13.126Z",
             "relationship_type": "indicates",
             "source_ref": "indicator--b06b0eb7-61dd-4338-a094-0290c380fbd8",
@@ -63,7 +66,7 @@
         },
         {
             "created": "2014-10-31T15:52:13.127Z",
-            "id": "relationship--738a6f2f-ed06-4bfd-a1f6-0741caa41f8d",
+            "id": "relationship--487e1967-cded-4a91-a46f-9974eabf6bad",
             "modified": "2014-10-31T15:52:13.127Z",
             "relationship_type": "indicates",
             "source_ref": "indicator--2e17f6fe-3a4d-438a-911a-e509ba1b9933",
@@ -73,7 +76,7 @@
         {
             "body_multipart": [
                 {
-                    "body_raw_ref": "file--4777a80e-b334-56ed-b8a1-7b19fe5c57ec",
+                    "body_raw_ref": "file--307d531c-7d74-5be6-b968-71ffb812b220",
                     "content_type": "text/plain"
                 }
             ],
@@ -83,20 +86,20 @@
             "type": "email-message"
         },
         {
-            "id": "file--4777a80e-b334-56ed-b8a1-7b19fe5c57ec",
-            "name": "Final Report",
+            "id": "file--307d531c-7d74-5be6-b968-71ffb812b220",
+            "name": "Final Report.doc.exe",
             "type": "file"
         },
         {
-            "created": "2018-08-18T14:14:42.346Z",
-            "first_observed": "2018-08-18T14:14:42.346Z",
+            "created": "2019-10-04T13:10:53.843Z",
+            "first_observed": "2019-10-04T13:10:53.843Z",
             "id": "observed-data--2305f359-ab46-4932-acaf-953c31cd8b22",
-            "last_observed": "2018-08-18T14:14:42.346Z",
-            "modified": "2018-08-18T14:14:42.346Z",
+            "last_observed": "2019-10-04T13:10:53.843Z",
+            "modified": "2019-10-04T13:10:53.843Z",
             "number_observed": 1,
             "object_refs": [
                 "email-message--69999a2b-a948-55af-b7ae-9bc614c72542",
-                "file--4777a80e-b334-56ed-b8a1-7b19fe5c57ec"
+                "file--307d531c-7d74-5be6-b968-71ffb812b220"
             ],
             "spec_version": "2.1",
             "type": "observed-data"

--- a/idioms-json-2.1-valid/network-socket-observable.json
+++ b/idioms-json-2.1-valid/network-socket-observable.json
@@ -7,13 +7,14 @@
                     "address_family": "AF_INET",
                     "is_listening": true,
                     "options": {
-                        "IP_MULTICAST_LOOP": true
-                    }
+                        "IP_MULTICAST_LOOP": 1
+                    },
+                    "x_elevator_local_address": "198.51.100.2"
                 }
             },
-            "id": "network-traffic--7bc29d43-c36d-5d67-9dc3-c151b34a1bcc",
+            "id": "network-traffic--bc151ba0-c40b-5777-8457-dc595b2fa727",
             "protocols": [
-                "TCP"
+                "tcp"
             ],
             "type": "network-traffic"
         },
@@ -25,7 +26,7 @@
             "modified": "2018-07-24T16:07:55.291Z",
             "number_observed": 1,
             "object_refs": [
-                "network-traffic--7bc29d43-c36d-5d67-9dc3-c151b34a1bcc"
+                "network-traffic--bc151ba0-c40b-5777-8457-dc595b2fa727"
             ],
             "spec_version": "2.1",
             "type": "observed-data"
@@ -33,4 +34,3 @@
     ],
     "type": "bundle"
 }
-

--- a/idioms-json-2.1-valid/threat-actor-leveraging-attack-patterns-and-malware.json
+++ b/idioms-json-2.1-valid/threat-actor-leveraging-attack-patterns-and-malware.json
@@ -1,83 +1,89 @@
 {
-  "id": "bundle--161f8ade-b67d-11e3-b8af-f01faf20d111",
-  "objects": [
-    {
-      "created": "2017-01-27T13:49:54.326Z",
-      "id": "identity--1621d4d4-b67d-11e3-9670-f01faf20d111",
-      "modified": "2017-01-27T13:49:54.326Z",
-      "name": "Adversary Bravo",
-      "spec_version": "2.1",
-      "type": "identity"
-    },
-    {
-      "created": "2017-01-27T13:49:54.326Z",
-      "id": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f",
-      "modified": "2017-01-27T13:49:54.326Z",
-      "name": "Adversary Bravo",
-      "sophistication": "unknown",
-      "spec_version": "2.1",
-      "type": "threat-actor"
-    },
-    {
-      "created": "2017-01-27T13:49:54.326Z",
-      "description": "Phishing",
-      "external_references": [
+    "id": "bundle--161f8ade-b67d-11e3-b8af-f01faf20d111",
+    "objects": [
         {
-          "external_id": "CAPEC-98",
-          "source_name": "capec"
+            "created": "2019-10-04T13:10:54.256Z",
+            "id": "identity--1621d4d4-b67d-11e3-9670-f01faf20d111",
+            "identity_class": "unknown",
+            "modified": "2019-10-04T13:10:54.256Z",
+            "name": "Adversary Bravo",
+            "spec_version": "2.1",
+            "type": "identity"
+        },
+        {
+            "created": "2019-10-04T13:10:54.256Z",
+            "id": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f",
+            "modified": "2019-10-04T13:10:54.256Z",
+            "name": "Adversary Bravo",
+            "sophistication": "unknown",
+            "spec_version": "2.1",
+            "type": "threat-actor"
+        },
+        {
+            "created": "2019-10-04T13:10:54.256Z",
+            "description": "Phishing",
+            "external_references": [
+                {
+                    "external_id": "CAPEC-98",
+                    "source_name": "capec"
+                }
+            ],
+            "id": "attack-pattern--8ac90ff3-ecf8-4835-95b8-6aea6a623df5",
+            "modified": "2019-10-04T13:10:54.256Z",
+            "name": "Phishing",
+            "spec_version": "2.1",
+            "type": "attack-pattern"
+        },
+        {
+            "created": "2019-10-04T13:10:54.256Z",
+            "extensions": {
+                "extension-definition--5efa53f9-cf17-4867-bb4f-4cd2ac055e7c": {
+                    "extension_type": "property-extension",
+                    "title": "Poison Ivy Variant d1c6"
+                }
+            },
+            "id": "malware--1621d4d2-b67d-11e3-ba9e-f01faf20d111",
+            "is_family": false,
+            "malware_types": [
+                "remote-access-trojan"
+            ],
+            "modified": "2019-10-04T13:10:54.256Z",
+            "name": "Poison Ivy Variant d1c6",
+            "spec_version": "2.1",
+            "type": "malware"
+        },
+        {
+            "created": "2019-10-04T13:10:54.256Z",
+            "id": "relationship--1621d4d4-b67d-11e3-9670-f01faf20d111",
+            "modified": "2019-10-04T13:10:54.256Z",
+            "relationship_type": "attributed-to",
+            "source_ref": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f",
+            "spec_version": "2.1",
+            "target_ref": "identity--1621d4d4-b67d-11e3-9670-f01faf20d111",
+            "type": "relationship"
+        },
+        {
+            "created": "2019-10-04T13:10:54.256Z",
+            "description": "Leverages Attack Pattern",
+            "id": "relationship--45e5b810-1cc0-4dd0-84ef-812eeab5f4da",
+            "modified": "2019-10-04T13:10:54.256Z",
+            "relationship_type": "uses",
+            "source_ref": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f",
+            "spec_version": "2.1",
+            "target_ref": "attack-pattern--8ac90ff3-ecf8-4835-95b8-6aea6a623df5",
+            "type": "relationship"
+        },
+        {
+            "created": "2019-10-04T13:10:54.256Z",
+            "description": "Leverages Malware",
+            "id": "relationship--56de4b8c-c304-4b28-8e54-c5f268ddf476",
+            "modified": "2019-10-04T13:10:54.256Z",
+            "relationship_type": "uses",
+            "source_ref": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f",
+            "spec_version": "2.1",
+            "target_ref": "malware--1621d4d2-b67d-11e3-ba9e-f01faf20d111",
+            "type": "relationship"
         }
-      ],
-      "id": "attack-pattern--8ac90ff3-ecf8-4835-95b8-6aea6a623df5",
-      "modified": "2017-01-27T13:49:54.326Z",
-      "name": "Phishing",
-      "spec_version": "2.1",
-      "type": "attack-pattern"
-    },
-    {
-      "created": "2017-01-27T13:49:54.326Z",
-      "description": "\n\nTITLE:\n\tPoison Ivy Variant d1c6",
-      "id": "malware--1621d4d2-b67d-11e3-ba9e-f01faf20d111",
-      "is_family": false,
-      "malware_types": [
-        "remote-access-trojan"
-      ],
-      "modified": "2017-01-27T13:49:54.326Z",
-      "name": "Poison Ivy Variant d1c6",
-      "spec_version": "2.1",
-      "type": "malware"
-    },
-    {
-      "created": "2017-01-27T13:49:54.326Z",
-      "id": "relationship--1621d4d4-b67d-11e3-9670-f01faf20d111",
-      "modified": "2017-01-27T13:49:54.326Z",
-      "relationship_type": "attributed-to",
-      "source_ref": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f",
-      "spec_version": "2.1",
-      "target_ref": "identity--1621d4d4-b67d-11e3-9670-f01faf20d111",
-      "type": "relationship"
-    },
-    {
-      "created": "2017-01-27T13:49:54.326Z",
-      "description": "Leverages Attack Pattern",
-      "id": "relationship--f287f87c-4179-45e7-96d3-db2784dc1976",
-      "modified": "2017-01-27T13:49:54.326Z",
-      "relationship_type": "uses",
-      "source_ref": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f",
-      "spec_version": "2.1",
-      "target_ref": "attack-pattern--8ac90ff3-ecf8-4835-95b8-6aea6a623df5",
-      "type": "relationship"
-    },
-    {
-      "created": "2017-01-27T13:49:54.326Z",
-      "description": "Leverages Malware",
-      "id": "relationship--d3c589e2-4db8-437f-afdb-da12929cdefa",
-      "modified": "2017-01-27T13:49:54.326Z",
-      "relationship_type": "uses",
-      "source_ref": "threat-actor--9a8a0d25-7636-429b-a99e-b2a73cd0f11f",
-      "spec_version": "2.1",
-      "target_ref": "malware--1621d4d2-b67d-11e3-ba9e-f01faf20d111",
-      "type": "relationship"
-    }
-  ],
-  "type": "bundle"
+    ],
+    "type": "bundle"
 }

--- a/idioms-json-2.1-valid/ttp-names-title-1.json
+++ b/idioms-json-2.1-valid/ttp-names-title-1.json
@@ -1,0 +1,22 @@
+{
+    "id": "bundle--22b3dcfc-1d87-4b35-ba61-7d7c14f28557",
+    "objects": [
+        {
+            "created": "2015-05-15T09:00:00.000Z",
+            "description": "Poison Ivy is a remote access tool that is freely available for download from its official web site at www.poisonivy-rat.com. First released in 2005, the tool has gone unchanged since 2008 with version 2.3.2. Poison Ivy includes features common to most Windows-based RATs, including key logging, screen capturing, video capturing, file transfers, system administration, password theft, and traffic relaying.\n\nPoison Ivy's wide availability and easy-to-use features make it a popular choice for all kinds of criminals. But it is probably most notable for its role in many high profile, targeted APT attacks.\n\nThese APTs pursue specific targets, using RATs to maintain a persistent presence within the target's network. They move laterally and escalate system privileges to extract sensitive information-whenever the attacker wants to do so.4,5 Because some RATs used in targeted attacks are widely available, determining whether an attack is part of a broader APT campaign can be difficult. Equally challenging is identifying malicious traffic to determine the attacker's post-compromise activities and assess overall damage-these RATs often encrypt their network communications after the initial exploit.\n\nIn 2011, three years after the most recent release of PIVY, attackers used the RAT to compromise security firm RSA and steal data about its SecureID authentication system. That data was subsequently used in other attacks. The RSA attack was linked to Chinese threat actors and described at the time as extremely sophisticated. Exploiting a zero-day vulnerability, the attack delivered PIVY as the payload. It was not an isolated incident. The campaign appears to have started in 2010, with many other companies compromised.\n\nPIVY also played a key role in the 2011 campaign known as Nitro that targeted chemical makers, government agencies, defense contractors, and human rights groups. Still active a year later, the Nitro attackers used a zero-day vulnerability in Java to deploy PIVY in 2012. Just recently, PIVY was the payload of a zero-day exploit in Internet Explorer used in what is known as a \"strategic web compromise\" attack against visitors to a U.S. government website and a variety of others.\n\nRATs require live, direct, real-time human interaction by the APT attacker. This characteristic is distinctly different from crimeware (malware focused on cybercrime), where the criminal can issue commands to their botnet of compromised endpoints whenever they please and set them to work on a common goal such as a spam relay. In contrast, RATs are much more personal and may indicate that you are dealing with a dedicated threat actor that is interested in your organization specifically.\n",
+            "extensions": {
+                "extension-definition--5efa53f9-cf17-4867-bb4f-4cd2ac055e7c": {
+                    "extension_type": "property-extension",
+                    "title": "Poison Ivy (PIVY) Title"
+                }
+            },
+            "id": "malware--82f13157-93a5-4486-ad00-c0397059d8ac",
+            "is_family": false,
+            "modified": "2015-05-15T09:00:00.000Z",
+            "name": "Poison Ivy (PIVY)",
+            "spec_version": "2.1",
+            "type": "malware"
+        }
+    ],
+    "type": "bundle"
+}

--- a/idioms-json-2.1-valid/ttp-names-title-4.json
+++ b/idioms-json-2.1-valid/ttp-names-title-4.json
@@ -1,0 +1,25 @@
+{
+    "id": "bundle--6f8bfbf8-2e54-4321-9316-2ce80f33322d",
+    "objects": [
+        {
+            "created": "2015-05-15T09:00:00.000Z",
+            "description": "Poison Ivy is a remote access tool that is freely available for download from its official web site at www.poisonivy-rat.com. First released in 2005, the tool has gone unchanged since 2008 with version 2.3.2. Poison Ivy includes features common to most Windows-based RATs, including key logging, screen capturing, video capturing, file transfers, system administration, password theft, and traffic relaying.\n\nPoison Ivy's wide availability and easy-to-use features make it a popular choice for all kinds of criminals. But it is probably most notable for its role in many high profile, targeted APT attacks.\n\nThese APTs pursue specific targets, using RATs to maintain a persistent presence within the target's network. They move laterally and escalate system privileges to extract sensitive information-whenever the attacker wants to do so.4,5 Because some RATs used in targeted attacks are widely available, determining whether an attack is part of a broader APT campaign can be difficult. Equally challenging is identifying malicious traffic to determine the attacker's post-compromise activities and assess overall damage-these RATs often encrypt their network communications after the initial exploit.\n\nIn 2011, three years after the most recent release of PIVY, attackers used the RAT to compromise security firm RSA and steal data about its SecureID authentication system. That data was subsequently used in other attacks. The RSA attack was linked to Chinese threat actors and described at the time as extremely sophisticated. Exploiting a zero-day vulnerability, the attack delivered PIVY as the payload. It was not an isolated incident. The campaign appears to have started in 2010, with many other companies compromised.\n\nPIVY also played a key role in the 2011 campaign known as Nitro that targeted chemical makers, government agencies, defense contractors, and human rights groups. Still active a year later, the Nitro attackers used a zero-day vulnerability in Java to deploy PIVY in 2012. Just recently, PIVY was the payload of a zero-day exploit in Internet Explorer used in what is known as a \"strategic web compromise\" attack against visitors to a U.S. government website and a variety of others.\n\nRATs require live, direct, real-time human interaction by the APT attacker. This characteristic is distinctly different from crimeware (malware focused on cybercrime), where the criminal can issue commands to their botnet of compromised endpoints whenever they please and set them to work on a common goal such as a spam relay. In contrast, RATs are much more personal and may indicate that you are dealing with a dedicated threat actor that is interested in your organization specifically.\n",
+            "extensions": {
+                "extension-definition--5efa53f9-cf17-4867-bb4f-4cd2ac055e7c": {
+                    "extension_type": "property-extension",
+                    "other_names": [
+                        "Poison Ivy (PIVY) 2",
+                        "Poison Ivy (PIVY) 3"
+                    ]
+                }
+            },
+            "id": "malware--497d1999-1dad-4977-9158-e25bb6b4fc42",
+            "is_family": false,
+            "modified": "2015-05-15T09:00:00.000Z",
+            "name": "Poison Ivy (PIVY) 1",
+            "spec_version": "2.1",
+            "type": "malware"
+        }
+    ],
+    "type": "bundle"
+}

--- a/idioms-json-2.1-valid/victim-targeting.json
+++ b/idioms-json-2.1-valid/victim-targeting.json
@@ -1,24 +1,43 @@
 {
-  "id": "bundle--bf35a4b5-e102-463d-9105-4d7a6e2d78bc",
-  "objects": [
-    {
-      "created": "2014-05-08T09:00:00.000Z",
-      "id": "campaign--c831ab93-ff84-9cda-2bd8-b094004da969",
-      "modified": "2014-05-08T09:00:00.000Z",
-      "name": "Operation Alpha",
-      "spec_version": "2.1",
-      "type": "campaign"
-    },
-    {
-      "created": "2014-05-08T09:00:00.000Z",
-      "description": "Targets",
-      "id": "relationship--88d1b107-8a5e-4329-ba81-937fecfaa637",
-      "modified": "2014-05-08T09:00:00.000Z",
-      "relationship_type": "uses",
-      "source_ref": "campaign--c831ab93-ff84-9cda-2bd8-b094004da969",
-      "spec_version": "2.1",
-      "type": "relationship"
-    }
-  ],
-  "type": "bundle"
+    "id": "bundle--bf35a4b5-e102-463d-9105-4d7a6e2d78bc",
+    "objects": [
+        {
+            "created": "2014-05-08T09:00:00.000Z",
+            "id": "campaign--c831ab93-ff84-9cda-2bd8-b094004da969",
+            "modified": "2014-05-08T09:00:00.000Z",
+            "name": "Operation Alpha",
+            "spec_version": "2.1",
+            "type": "campaign"
+        },
+        {
+            "created": "2014-05-08T09:00:00.000Z",
+            "extensions": {
+                "extension-definition--8f0b8ed7-c7ad-4650-babe-c4c45cac4a0b": {
+                    "extension_type": "property-extension",
+                    "targeted_information": [
+                        "Information Assets - Customer PII",
+                        "Information Assets - Financial Data"
+                    ]
+                }
+            },
+            "id": "identity--4fde045a-b25f-f035-e8d0-29c9d5130cd9",
+            "identity_class": "unknown",
+            "modified": "2014-05-08T09:00:00.000Z",
+            "name": "Victim Targeting: Customer PII and Financial Data",
+            "spec_version": "2.1",
+            "type": "identity"
+        },
+        {
+            "created": "2014-05-08T09:00:00.000Z",
+            "description": "Targets",
+            "id": "relationship--09ae7018-6967-4436-8599-d9f9cbffc58f",
+            "modified": "2014-05-08T09:00:00.000Z",
+            "relationship_type": "targets",
+            "source_ref": "campaign--c831ab93-ff84-9cda-2bd8-b094004da969",
+            "spec_version": "2.1",
+            "target_ref": "identity--4fde045a-b25f-f035-e8d0-29c9d5130cd9",
+            "type": "relationship"
+        }
+    ],
+    "type": "bundle"
 }

--- a/stix2elevator/cli.py
+++ b/stix2elevator/cli.py
@@ -97,7 +97,7 @@ def _get_arg_parser(is_script=True):
     parser.add_argument(
         "--validator-args",
         help="Arguments to pass to stix2-validator. Default: --strict-types\n\n"
-             "Example: stix2_elevator.py <file> --validator-args=\"-v 2.0 --strict-types -d 212\"",
+             "Example: stix2_elevator.py <file> --validator-args=\"-v --strict-types -d 212\"",
         dest="validator_args",
         action="store",
         default=""

--- a/stix2elevator/convert_stix.py
+++ b/stix2elevator/convert_stix.py
@@ -1282,7 +1282,7 @@ def handle_missing_identity_ref_properties(container, instance2x, sources, env, 
                 id_info = id2x["id"]
             identities.append(id_info)
     if not identities == list():
-        handle_missing_string_property(container, property_name, identities, instance2x["id"], True)
+        handle_missing_string_property(container, property_name, identities, instance2x["id"], True, use_custom_name=False)
 # incident
 
 
@@ -1305,7 +1305,7 @@ def handle_missing_properties_of_incident(incident_instance, incident, env):
             if reporter.identity:
                 id2x = convert_identity(reporter.identity, env)
                 env.bundle_instance["objects"].append(id2x)
-                handle_missing_string_property(container, "reporter", id2x["id"], incident_instance["id"])
+                handle_missing_string_property(container, "reporter", id2x["id"], incident_instance["id"], use_custom_name=False)
 
         if incident.responders is not None:
             handle_missing_identity_ref_properties(container, incident_instance, incident.responders, env, "responders")
@@ -1324,7 +1324,7 @@ def handle_missing_properties_of_incident(incident_instance, incident, env):
             # FIXME: add impact_assessment to description
             info("Incident Impact Assessment in %s is not handled, yet", 815, incident_instance["id"])
 
-        handle_missing_string_property(container, "status", incident.status, incident_instance["id"])
+        handle_missing_string_property(container, "status", incident.status, incident_instance["id"], use_custom_name=False)
 
         fill_in_extension_properties(incident_instance, container, extension_definition_id)
 


### PR DESCRIPTION
Changes to stepper:
- remove "x_" when replacing custom properties with extensions
- if created property in process, change to created_time
- move "x_" properties into the extension property
- for custom cyber observables, create a "new-sco" extension
- convert High/Low confidence string literals with integers from Appendix A of the spec
- create an actual Incident SDO, if there exists a Incident custom object in 2.0 
- remove "x-" from ids from relationships.
- force creation of extensions instead of custom 
