### PR TITLE
Remove deprecated elevate methods

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -218,10 +218,15 @@ You can also use this library to integrate STIX elevation into your own tools.
 .. code-block:: python
 
     # Elevate a STIX 1.x via filename
+    # Use set_option_value to override default elevator options
+    # Read the documentation for options
     from stix2elevator import elevate
-    from stix2elevator.options import initialize_options
+    from stix2elevator.options import initialize_options, set_option_value
 
     initialize_options()
+    set_option_value("missing_policy", "no_policy")
+    set_option_value("spec_version", "2.1")
+
     results = elevate("stix_file.xml")
     print(results)
 
@@ -230,10 +235,15 @@ The same method can also accept a string as an argument.
 .. code-block:: python
 
     # Elevate a STIX 1.x via string
+    # Use set_option_value to override default elevator options
+    # Read the documentation for options
     from stix2elevator import elevate
-    from stix2elevator.options import initialize_options
+    from stix2elevator.options import initialize_options, set_option_value
 
     initialize_options()
+    set_option_value("missing_policy", "no_policy")
+    set_option_value("spec_version", "2.1")
+
     results = elevate("<stix:Package...")
     print(results)
 

--- a/docs/command-line.rst
+++ b/docs/command-line.rst
@@ -1,4 +1,4 @@
-​Command Line Interface
+Command Line Interface
 ===========================
 
 The elevator comes with a bundled script which you can use to elevate

--- a/docs/conversion-issues.rst
+++ b/docs/conversion-issues.rst
@@ -1,6 +1,6 @@
 .. _conversion_issues:
 
-​Conversion Issues
+Conversion Issues
 =====================
 
 This section discusses some techniques to facilitate the conversion of

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -1,4 +1,4 @@
-​Introduction
+Introduction
 =================
 
 The stix2-elevator is a python script written to automatically convert STIX 1.x content to STIX 2.x.  It is available at

--- a/stix2elevator/__init__.py
+++ b/stix2elevator/__init__.py
@@ -4,7 +4,6 @@ import json
 import logging
 import os
 import re
-import warnings
 
 # external
 import cybox.utils.caches
@@ -120,7 +119,6 @@ def elevate(stix_package):
             raise TypeError("Must be an instance of stix.core.STIXPackage")
     except (OSError, IOError, lxml.etree.Error) as ex:
         log.error("Error occurred: %s", ex)
-        # log.exception(ex)
         return None
 
     try:
@@ -151,152 +149,3 @@ def elevate(stix_package):
     except ValidationError as ex:
         output.error("Validation error occurred: '{}'".format(ex))
         output.error("Error Code: {}".format(codes.EXIT_VALIDATION_ERROR))
-
-
-def elevate_file(fn):
-    # TODO:  combine elevate_file, elevate_string and elevate_package
-    warnings.warn("This method is deprecated and will be removed in the next major release. Please use elevate() instead.", DeprecationWarning)
-    global MESSAGES_GENERATED
-    MESSAGES_GENERATED = False
-    print("Results produced by the stix2-elevator are not for production purposes.")
-    clear_globals()
-
-    validator_options = get_validator_options()
-
-    try:
-        output.set_level(validator_options.verbose)
-        output.set_silent(validator_options.silent)
-
-        if os.path.isfile(fn) is False:
-            raise IOError("The file '{}' was not found.".format(fn))
-
-        container = stixmarx.parse(fn)
-        stix_package = container.package
-        set_option_value("marking_container", container)
-
-        if not isinstance(stix_package, STIXPackage):
-            raise TypeError("Must be an instance of stix.core.STIXPackage")
-
-        setup_logger(stix_package.id_)
-        warn("Results produced by the stix2-elevator may generate warning messages which should be investigated.", 201)
-        env = Environment(get_option_value("package_created_by_id"))
-        json_string = json.dumps(convert_package(stix_package, env),
-                                 ensure_ascii=False,
-                                 indent=4,
-                                 separators=(',', ': '),
-                                 sort_keys=True)
-
-        validation_results = validate_stix2_string(json_string, validator_options, fn)
-        output.print_results([validation_results])
-
-        if get_option_value("policy") == "no_policy":
-            return json_string
-        else:
-            if not MESSAGES_GENERATED and validation_results._is_valid:
-                return json_string
-            else:
-                return None
-
-    except ValidationError as ex:
-        output.error("Validation error occurred: '{}'".format(ex))
-        output.error("Error Code: {}".format(codes.EXIT_VALIDATION_ERROR))
-    except (OSError, IOError, lxml.etree.Error) as ex:
-        log.error("Error occurred: %s", ex)
-        # log.exception(ex)
-
-
-def elevate_string(string):
-    warnings.warn("This method is deprecated and will be removed in the next major release. Please use elevate() instead.", DeprecationWarning)
-    global MESSAGES_GENERATED
-    MESSAGES_GENERATED = False
-    clear_globals()
-
-    validator_options = get_validator_options()
-
-    try:
-        output.set_level(validator_options.verbose)
-        output.set_silent(validator_options.silent)
-
-        bytes_obj = io.StringIO(string)
-        container = stixmarx.parse(bytes_obj)
-        stix_package = container.package
-        set_option_value("marking_container", container)
-
-        if not isinstance(stix_package, STIXPackage):
-            raise TypeError("Must be an instance of stix.core.STIXPackage")
-
-        setup_logger(stix_package.id_)
-        warn("Results produced by the stix2-elevator are not for production purposes.", 201)
-        env = Environment(get_option_value("package_created_by_id"))
-        json_string = json.dumps(convert_package(stix_package, env),
-                                 ensure_ascii=False,
-                                 indent=4,
-                                 separators=(',', ': '),
-                                 sort_keys=True)
-
-        validation_results = validate_stix2_string(json_string, validator_options)
-        output.print_results([validation_results])
-
-        if get_option_value("policy") == "no_policy":
-            return json_string
-        else:
-
-            if not MESSAGES_GENERATED and validation_results._is_valid:
-                return json_string
-            else:
-                return None
-
-    except ValidationError as ex:
-        output.error("Validation error occurred: '{}'".format(ex))
-        output.error("Error Code: {}".format(codes.EXIT_VALIDATION_ERROR))
-    except (OSError, IOError, lxml.etree.Error) as ex:
-        log.error("Error occurred: %s", ex)
-        # log.exception(ex)
-
-
-def elevate_package(package):
-    warnings.warn("This method is deprecated and will be removed in the next major release. Please use elevate() instead.", DeprecationWarning)
-    global MESSAGES_GENERATED
-    MESSAGES_GENERATED = False
-    clear_globals()
-
-    validator_options = get_validator_options()
-
-    try:
-        output.set_level(validator_options.verbose)
-        output.set_silent(validator_options.silent)
-
-        # It needs to be re-parsed.
-        container = stixmarx.parse(io.BytesIO(package.to_xml()))
-        stix_package = container.package
-        set_option_value("marking_container", container)
-
-        if not isinstance(stix_package, STIXPackage):
-            raise TypeError("Must be an instance of stix.core.STIXPackage")
-
-        setup_logger(stix_package.id_)
-        warn("Results produced by the stix2-elevator are not for production purposes.", 201)
-        env = Environment(get_option_value("package_created_by_id"))
-        json_string = json.dumps(convert_package(stix_package, env),
-                                 ensure_ascii=False,
-                                 indent=4,
-                                 separators=(',', ': '),
-                                 sort_keys=True)
-
-        validation_results = validate_stix2_string(json_string, validator_options)
-        output.print_results([validation_results])
-
-        if get_option_value("policy") == "no_policy":
-            return json_string
-        else:
-            if not MESSAGES_GENERATED and validation_results._is_valid:
-                return json_string
-            else:
-                return None
-
-    except ValidationError as ex:
-        output.error("Validation error occurred: '{}'".format(ex))
-        output.error("Error Code: {}".format(codes.EXIT_VALIDATION_ERROR))
-    except (OSError, IOError, lxml.etree.Error) as ex:
-        log.error("Error occurred: %s", ex)
-        # log.exception(ex)

--- a/stix2elevator/test/test_main.py
+++ b/stix2elevator/test/test_main.py
@@ -9,9 +9,7 @@ from stix.core import STIXPackage
 import stixmarx
 
 # internal
-from stix2elevator import (
-    elevate, elevate_file, elevate_package, elevate_string, options
-)
+from stix2elevator import elevate, options
 from stix2elevator.options import (
     ElevatorOptions, get_option_value, initialize_options, set_option_value
 )
@@ -120,51 +118,5 @@ def test_elevate_with_file():
     archive_file = os.path.join(xml_idioms_dir, "141-TLP-marking-structures.xml")
 
     json_result = elevate(archive_file)
-    assert json_result
-    print(json_result)
-
-
-def test_deprecated_elevate_file():
-    setup_options()
-
-    directory = os.path.dirname(__file__)
-    xml_idioms_dir = find_dir(directory, "idioms-xml")
-    archive_file = os.path.join(xml_idioms_dir, "141-TLP-marking-structures.xml")
-
-    with pytest.warns(DeprecationWarning):
-        json_result = elevate_file(archive_file)
-
-    assert json_result
-    print(json_result)
-
-
-def test_deprecated_elevate_string():
-    setup_options()
-
-    directory = os.path.dirname(__file__)
-    xml_idioms_dir = find_dir(directory, "idioms-xml")
-    archive_file = os.path.join(xml_idioms_dir, "141-TLP-marking-structures.xml")
-
-    with pytest.warns(DeprecationWarning):
-        with io.open(archive_file, mode="r", encoding="utf-8") as f:
-            input_stix = f.read()
-        json_result = elevate_string(input_stix)
-
-    assert json_result
-    print(json_result)
-
-
-def test_deprecated_elevate_package():
-    setup_options()
-
-    directory = os.path.dirname(__file__)
-    xml_idioms_dir = find_dir(directory, "idioms-xml")
-    archive_file = os.path.join(xml_idioms_dir, "141-TLP-marking-structures.xml")
-
-    with pytest.warns(DeprecationWarning):
-        with io.open(archive_file, mode="r", encoding="utf-8") as f:
-            input_stix = f.read()
-        json_result = elevate_package(STIXPackage.from_xml(io.StringIO(input_stix)))
-
     assert json_result
     print(json_result)


### PR DESCRIPTION
- Removes `elevate_file`, `elevate_string`, and `elevate_package` which were flagged for removal.
- Removes tests associated with deprecated methods.
- Minor documentation changes.